### PR TITLE
feat: support media URL message sending

### DIFF
--- a/baileys_service/server.js
+++ b/baileys_service/server.js
@@ -419,27 +419,40 @@ app.post('/disconnect/:instanceId', (req, res) => {
 
 app.post('/send/:instanceId', async (req, res) => {
     const { instanceId } = req.params;
-    const { to, message, type = 'text' } = req.body;
-    
+    const { to, message, type = 'text', imageData, mediaUrl, fileName } = req.body;
+
     const instance = instances.get(instanceId);
     if (!instance || !instance.connected || !instance.sock) {
         return res.status(400).json({ error: 'Instância não conectada', instanceId: instanceId });
     }
-    
+
     try {
         const jid = to.includes('@') ? to : `${to}@s.whatsapp.net`;
-        
+        const caption = message || '';
+        const mediaTypes = ['image', 'video', 'audio', 'document'];
+
         if (type === 'text') {
             await instance.sock.sendMessage(jid, { text: message });
-        } else if (type === 'image' && req.body.imageData) {
-            // Handle image sending (base64)
-            const buffer = Buffer.from(req.body.imageData, 'base64');
-            await instance.sock.sendMessage(jid, { 
-                image: buffer,
-                caption: message || ''
-            });
+        } else if (mediaTypes.includes(type)) {
+            if (!imageData && !mediaUrl) {
+                return res.status(400).json({ error: 'Missing media data' });
+            }
+
+            if (type === 'image' && imageData) {
+                // Handle image sending (base64)
+                const buffer = Buffer.from(imageData, 'base64');
+                await instance.sock.sendMessage(jid, { image: buffer, caption });
+            } else {
+                const msg = { [type]: { url: mediaUrl }, caption };
+                if (type === 'document' && fileName) {
+                    msg.fileName = fileName;
+                }
+                await instance.sock.sendMessage(jid, msg);
+            }
+        } else {
+            return res.status(400).json({ error: `Unsupported message type: ${type}` });
         }
-        
+
         console.log(`📤 Mensagem enviada da instância ${instanceId} para ${to}`);
         res.json({ success: true, instanceId: instanceId });
     } catch (error) {


### PR DESCRIPTION
## Summary
- handle media URLs for image, video, audio, and document messages
- validate that media data exists for media types
- improve error handling for send failures

## Testing
- `node --check baileys_service/server.js`
- `cd baileys_service && npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c5c7d83da0832f8f20d220e4f59a02