### PR TITLE
Add primary color CSS variable for campaign styling

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -118,6 +118,7 @@ HTML_APP = '''<!DOCTYPE html>
         
         :root {
             --primary: #128c7e;
+            --primary-color: var(--primary);
             --primary-dark: #075e54;
             --primary-light: #25d366;
             --bg-primary: #f0f2f5;


### PR DESCRIPTION
## Summary
- define a `--primary-color` CSS custom property to match the existing primary palette value so campaign UI elements can resolve the variable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8667f3e88832faf6c649f1cd37c57