### PR TITLE
Sync selected campaign groups with API

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -6391,15 +6391,18 @@ HTML_APP = '''<!DOCTYPE html>
                     return;
                 }
 
-                container.innerHTML = groups.map(group => `
-                    <div class="group-item" onclick="toggleGroupSelection('${group.id}', '${group.name}', '${instanceId}')">
-                        <input type="checkbox" id="group-${group.id}" onchange="event.stopPropagation()">
+                container.innerHTML = groups.map(group => {
+                    const isSelected = selectedCampaignGroups.some(g => g.id === group.id);
+                    return `
+                    <div class="group-item ${isSelected ? 'selected' : ''}" onclick="toggleGroupSelection('${group.id}', '${group.name}', '${instanceId}')">
+                        <input type="checkbox" id="group-${group.id}" ${isSelected ? 'checked' : ''} onchange="event.stopPropagation()">
                         <div class="group-info">
                             <div class="group-name">${group.name}</div>
                             <div class="group-participants">${group.participants?.length || 0} participantes</div>
                         </div>
                     </div>
-                `).join('');
+                `;
+                }).join('');
             } catch (error) {
                 console.error('❌ Erro ao carregar grupos:', error);
                 container.innerHTML = `<div class="empty-state"><p>Erro ao carregar grupos</p><p>${error.message}</p></div>`;
@@ -6492,8 +6495,12 @@ HTML_APP = '''<!DOCTYPE html>
         async function loadExistingCampaignGroups(campaignId) {
             try {
                 const response = await fetch(`${WHATSFLOW_API_URL}/api/campaigns/${campaignId}/groups`);
-                const groups = await response.json();
-                selectedCampaignGroups = groups;
+                const data = await response.json();
+                selectedCampaignGroups = data.map(g => ({
+                    id: g.group_id,
+                    name: g.group_name,
+                    instance_id: g.instance_id
+                }));
                 updateSelectedCampaignGroups();
             } catch (error) {
                 console.error('❌ Erro ao carregar grupos da campanha:', error);


### PR DESCRIPTION
## Summary
- map the existing campaign group API response into the selection structure used by the UI
- preselect checkboxes and styling for campaign groups already linked to the campaign

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c866807164832f89182e55a2b8589d