### PR TITLE
feat: add MinIO upload support

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -25,6 +25,9 @@ from typing import Set, Dict, Any, Optional
 from datetime import timedelta
 import pytz
 import requests
+import io
+import cgi
+from minio import Minio
 
 # Try to import websockets, fallback gracefully if not available
 try:
@@ -39,6 +42,17 @@ except ImportError:
 DB_FILE = "whatsflow.db"
 PORT = 8889
 WEBSOCKET_PORT = 8890
+
+MINIO_ENDPOINT = os.environ.get("MINIO_ENDPOINT", "localhost:9000")
+MINIO_ACCESS_KEY = os.environ.get("MINIO_ACCESS_KEY")
+MINIO_SECRET_KEY = os.environ.get("MINIO_SECRET_KEY")
+MINIO_BUCKET = os.environ.get("MINIO_BUCKET", "meu-bucket")
+minio_client = Minio(
+    MINIO_ENDPOINT,
+    access_key=MINIO_ACCESS_KEY,
+    secret_key=MINIO_SECRET_KEY,
+    secure=False
+)
 
 # Candidate URLs for the Baileys service. We try to auto-discover the machine's
 # public IP so the script works even when the server address changes.
@@ -80,6 +94,18 @@ def resolve_baileys_url() -> str:
 
 
 API_BASE_URL = resolve_baileys_url()
+
+
+def ensure_minio_bucket():
+    if not minio_client.bucket_exists(MINIO_BUCKET):
+        minio_client.make_bucket(MINIO_BUCKET)
+
+
+def upload_to_minio(filename: str, data: bytes) -> str:
+    ensure_minio_bucket()
+    object_name = f"{int(time.time() * 1000)}{os.path.splitext(filename)[1]}"
+    minio_client.put_object(MINIO_BUCKET, object_name, io.BytesIO(data), len(data))
+    return f"http://{MINIO_ENDPOINT}/{MINIO_BUCKET}/{object_name}"
 
 # WebSocket clients management
 if WEBSOCKETS_AVAILABLE:
@@ -2668,9 +2694,20 @@ HTML_APP = '''<!DOCTYPE html>
                         </div>
                         
                         <div class="message-input-area" id="messageInputArea">
-                            <textarea class="message-input" id="messageInput" 
-                                      placeholder="Digite sua mensagem..." 
+                            <textarea class="message-input" id="messageInput"
+                                      placeholder="Digite sua mensagem..."
                                       onkeypress="handleMessageKeyPress(event)"></textarea>
+                            <input type="file" id="mediaFile" style="display:none" onchange="uploadMediaFile(this.files[0])">
+                            <input type="hidden" id="manualMediaUrl">
+                            <select id="manualMessageType" class="btn btn-secondary">
+                                <option value="image">Imagem</option>
+                                <option value="video">Vídeo</option>
+                                <option value="audio">Áudio</option>
+                                <option value="document">Documento</option>
+                            </select>
+                            <button class="btn btn-secondary" onclick="document.getElementById('mediaFile').click()" title="Selecionar mídia">
+                                📎
+                            </button>
                             <button class="btn btn-success" onclick="sendMessage()">
                                 📤 Enviar
                             </button>
@@ -4177,7 +4214,29 @@ HTML_APP = '''<!DOCTYPE html>
                 sendMessage();
             }
         }
-        
+
+        async function uploadMediaFile(file) {
+            if (!file) return;
+            const formData = new FormData();
+            formData.append('file', file);
+            try {
+                const resp = await fetch('/api/upload', {
+                    method: 'POST',
+                    body: formData
+                });
+                const data = await resp.json();
+                if (data.url) {
+                    document.getElementById('manualMediaUrl').value = data.url;
+                    alert('✅ Arquivo enviado');
+                } else {
+                    alert('❌ Erro no upload');
+                }
+            } catch (err) {
+                console.error(err);
+                alert('❌ Erro no upload');
+            }
+        }
+
         async function sendMessage() {
             if (!currentChat) {
                 alert('❌ Selecione uma conversa primeiro');
@@ -8045,6 +8104,8 @@ class WhatsFlowRealHandler(BaseHTTPRequestHandler):
             self.handle_whatsapp_disconnected()
         elif self.path == '/api/chats/import':
             self.handle_import_chats()
+        elif self.path == '/api/upload':
+            self.handle_upload_media()
         elif self.path.startswith('/api/whatsapp/connect/'):
             instance_id = self.path.split('/')[-1]
             self.handle_connect_instance(instance_id)
@@ -8330,6 +8391,24 @@ class WhatsFlowRealHandler(BaseHTTPRequestHandler):
         except Exception as e:
             print(f"❌ Erro ao processar desconexão: {e}")
             self.send_json_response({"error": str(e)}, 500)
+
+    def handle_upload_media(self):
+        try:
+            form = cgi.FieldStorage(
+                fp=self.rfile,
+                headers=self.headers,
+                environ={
+                    'REQUEST_METHOD': 'POST',
+                    'CONTENT_TYPE': self.headers['Content-Type'],
+                },
+            )
+            file_item = form['file']
+            data = file_item.file.read()
+            url = upload_to_minio(file_item.filename, data)
+            self.send_json_response({'url': url})
+        except Exception as e:
+            logger.exception("Erro no upload de mídia")
+            self.send_json_response({'error': str(e)}, 500)
 
     def handle_import_chats(self):
         try:


### PR DESCRIPTION
## Summary
- add MinIO config and helper to upload files
- expose `/api/upload` endpoint to store media and return URL
- allow selecting media in chat UI with automatic upload

## Testing
- `python -m py_compile whats3/whatsflow-real.py`


------
https://chatgpt.com/codex/tasks/task_e_68c896d60338832f8321d357a0e69c04