### PR TITLE
Replace pytz with zoneinfo for Brazil timezone

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -12,6 +12,7 @@ import json
 import sqlite3
 import uuid
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 import os
 import subprocess
 import sys
@@ -24,7 +25,6 @@ import logging
 import warnings
 from typing import Set, Dict, Any, Optional, Tuple
 from datetime import timedelta
-import pytz
 import io
 import importlib
 import cgi
@@ -7946,7 +7946,7 @@ class MessageScheduler:
         """Check for messages that need to be sent"""
         conn = None
         try:
-            brazil_tz = pytz.timezone('America/Sao_Paulo')
+            brazil_tz = ZoneInfo('America/Sao_Paulo')
             now_brazil = datetime.now(brazil_tz)
 
             # Use standardized database connection with retry logic
@@ -9817,17 +9817,21 @@ class WhatsFlowRealHandler(BaseHTTPRequestHandler):
         try:
             from datetime import datetime, timedelta
             import time
-            import pytz
+            from zoneinfo import ZoneInfo
 
-            brazil_tz = pytz.timezone('America/Sao_Paulo')
+            brazil_tz = ZoneInfo('America/Sao_Paulo')
             now = datetime.now(brazil_tz)
             hour, minute = map(int, schedule_time.split(':'))
 
             if schedule_type == 'once':
                 if schedule_date:
                     target_date = datetime.strptime(schedule_date, '%Y-%m-%d')
-                    target_datetime = brazil_tz.localize(
-                        target_date.replace(hour=hour, minute=minute, second=0, microsecond=0)
+                    target_datetime = target_date.replace(
+                        hour=hour,
+                        minute=minute,
+                        second=0,
+                        microsecond=0,
+                        tzinfo=brazil_tz,
                     )
                     if target_datetime > now:
                         return target_datetime.isoformat()
@@ -10034,9 +10038,9 @@ class WhatsFlowRealHandler(BaseHTTPRequestHandler):
             
             # Calculate next run using Brazil timezone
             from datetime import datetime, timedelta
-            import pytz
-            
-            brazil_tz = pytz.timezone('America/Sao_Paulo')
+            from zoneinfo import ZoneInfo
+
+            brazil_tz = ZoneInfo('America/Sao_Paulo')
             now_brazil = datetime.now(brazil_tz)
             
             # Parse schedule time
@@ -10048,7 +10052,13 @@ class WhatsFlowRealHandler(BaseHTTPRequestHandler):
                     return
                     
                 target_date = datetime.strptime(schedule_date, '%Y-%m-%d')
-                target_datetime = brazil_tz.localize(target_date.replace(hour=hour, minute=minute, second=0))
+                target_datetime = target_date.replace(
+                    hour=hour,
+                    minute=minute,
+                    second=0,
+                    microsecond=0,
+                    tzinfo=brazil_tz,
+                )
                 
                 if target_datetime <= now_brazil:
                     self.send_json_response({"error": "Data/horário deve ser no futuro"}, 400)


### PR DESCRIPTION
## Summary
- switch the real WhatsFlow scheduler to use Python's built-in zoneinfo instead of pytz
- update all scheduling helpers to build aware datetimes with ZoneInfo for America/Sao_Paulo

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8add3bd7c832f8ecccb9229ad79ff