### PR TITLE
Stop auto-installing MinIO at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # Here are your Instructions
 
+## Dependências Python (WhatsFlow Real)
+
+A versão real do WhatsFlow requer a biblioteca [`minio`](https://pypi.org/project/minio/)
+para realizar uploads ao servidor de arquivos. Antes de executar
+`whatsflow-real.py`, instale essa dependência manualmente:
+
+```bash
+python3 -m pip install minio
+```
+
+Se o pacote não estiver disponível, o aplicativo exibirá um erro orientando a
+instalação manual.
+
 ## CORS liberado
 
 O serviço `baileys_service` e os demais servidores utilizam `cors` com

--- a/instalar-real.sh
+++ b/instalar-real.sh
@@ -29,6 +29,15 @@ fi
 PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
 echo "✅ Python $PYTHON_VERSION encontrado"
 
+echo "🔍 Verificando dependências Python (minio)..."
+if ! python3 -c "import minio" >/dev/null 2>&1; then
+    echo "❌ Biblioteca 'minio' não encontrada!"
+    echo "   Instale executando: python3 -m pip install minio"
+    echo "   Depois execute novamente este instalador."
+    exit 1
+fi
+echo "✅ Biblioteca 'minio' disponível"
+
 # Verificar Node.js
 echo "🔍 Verificando Node.js..."
 if ! command -v node &> /dev/null; then

--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -123,17 +123,11 @@ def _ensure_minio_dependency():
     try:
         Minio = importlib.import_module("minio").Minio
         return Minio
-    except ModuleNotFoundError:
-        print("📦 Instalando dependência 'minio' (necessária para uploads)...")
-        try:
-            subprocess.check_call([sys.executable, "-m", "pip", "install", "minio"])
-        except Exception as exc:
-            raise RuntimeError(
-                "Não foi possível instalar a biblioteca 'minio'. "
-                "Instale-a manualmente executando: pip install minio"
-            ) from exc
-        Minio = importlib.import_module("minio").Minio
-        return Minio
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "Biblioteca 'minio' não encontrada. "
+            "Instale-a manualmente executando: python3 -m pip install minio"
+        ) from exc
 
 
 def get_minio_client():


### PR DESCRIPTION
## Summary
- stop whatsflow-real.py from attempting to install the minio dependency automatically and raise a clear error instead
- document the need to install the minio package manually in the README
- update instalar-real.sh to check for the minio module and instruct the user to install it if missing

## Testing
- python3 -m compileall whatsflow-real.py

------
https://chatgpt.com/codex/tasks/task_e_68c8add5666c832fa8a95fd5a84ab2fe