### PR TITLE
Add settings view with Minio credentials form

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2400,3 +2400,170 @@ body {
 .close-qr-btn:hover {
   background: #c53030;
 }
+
+/* Settings */
+.settings {
+  background: white;
+  border-radius: 16px;
+  padding: 2rem;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+}
+
+.settings h2 {
+  color: #2d3748;
+  margin-bottom: 1.5rem;
+}
+
+.settings-layout {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.settings-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 220px;
+}
+
+.settings-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border: none;
+  border-radius: 8px;
+  background: #f8fafc;
+  color: #2d3748;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  text-align: left;
+}
+
+.settings-nav-item:hover {
+  background: rgba(102, 126, 234, 0.15);
+  color: #4c51bf;
+}
+
+.settings-nav-item.active {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+}
+
+.settings-subnav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-left: 1.5rem;
+}
+
+.settings-subnav-item {
+  background: transparent;
+  border: none;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  color: #4a5568;
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.3s ease;
+}
+
+.settings-subnav-item:hover {
+  background: rgba(102, 126, 234, 0.1);
+  color: #4c51bf;
+}
+
+.settings-subnav-item.active {
+  background: #667eea;
+  color: white;
+}
+
+.settings-content {
+  flex: 1;
+  min-width: 260px;
+}
+
+.settings-card {
+  background: #f8fafc;
+  border-radius: 12px;
+  padding: 2rem;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.05);
+}
+
+.settings-card h3 {
+  color: #2d3748;
+  margin-bottom: 0.75rem;
+}
+
+.settings-description {
+  color: #64748b;
+  margin-bottom: 1.5rem;
+  line-height: 1.6;
+}
+
+.settings-alert {
+  padding: 1rem 1.25rem;
+  border-radius: 8px;
+  font-weight: 500;
+  margin-bottom: 1.5rem;
+}
+
+.settings-alert.success {
+  background: #f0fff4;
+  color: #22543d;
+  border: 1px solid #9ae6b4;
+}
+
+.settings-alert.error {
+  background: #fed7d7;
+  color: #c53030;
+  border: 1px solid #fc8181;
+}
+
+.settings-form {
+  display: grid;
+  gap: 1.5rem;
+  max-width: 500px;
+}
+
+.settings-form input {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.settings-form input:focus {
+  outline: none;
+  border-color: #667eea;
+  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.15);
+}
+
+.settings-form .save-button {
+  justify-self: flex-start;
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
+@media (max-width: 768px) {
+  .settings-layout {
+    flex-direction: column;
+  }
+
+  .settings-sidebar {
+    flex-direction: row;
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
+  }
+
+  .settings-subnav {
+    flex-direction: row;
+    margin-left: 0;
+    padding-left: 0.5rem;
+  }
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,7 @@ import axios from 'axios';
 import FlowEditor from './components/FlowEditor';
 import FlowList from './components/FlowList';
 import MessagesCenter from './components/MessagesCenter';
+import Settings from './components/Settings';
 import WhatsAppInstances from './components/WhatsAppInstances';
 
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
@@ -60,12 +61,19 @@ const Navigation = ({ currentView, onViewChange }) => {
           <span className="nav-icon">💬</span>
           <span>Mensagens</span>
         </button>
-        <button 
+        <button
           className={`nav-item ${currentView === 'instances' ? 'active' : ''}`}
           onClick={() => onViewChange('instances')}
         >
           <span className="nav-icon">📱</span>
           <span>Instâncias</span>
+        </button>
+        <button
+          className={`nav-item ${currentView === 'settings' ? 'active' : ''}`}
+          onClick={() => onViewChange('settings')}
+        >
+          <span className="nav-icon">⚙️</span>
+          <span>Configurações</span>
         </button>
       </div>
     </nav>
@@ -437,6 +445,10 @@ function App() {
 
           {currentView === 'instances' && (
             <WhatsAppInstances />
+          )}
+
+          {currentView === 'settings' && (
+            <Settings />
           )}
         </div>
       </main>

--- a/frontend/src/components/Settings.js
+++ b/frontend/src/components/Settings.js
@@ -1,0 +1,155 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+
+const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
+const API = `${BACKEND_URL}/api`;
+
+const Settings = () => {
+  const [activeSection, setActiveSection] = useState('credentials');
+  const [activeSubSection, setActiveSubSection] = useState('minio');
+  const [formData, setFormData] = useState({
+    accessKey: '',
+    secretKey: '',
+    bucket: '',
+    url: ''
+  });
+  const [status, setStatus] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleInputChange = (event) => {
+    const { name, value } = event.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setLoading(true);
+    setStatus(null);
+
+    try {
+      await axios.post(`${API}/settings/minio`, formData);
+      setStatus({
+        type: 'success',
+        message: 'Credenciais salvas com sucesso!'
+      });
+    } catch (error) {
+      const message =
+        error.response?.data?.message ||
+        'Não foi possível salvar as credenciais. Tente novamente.';
+      setStatus({
+        type: 'error',
+        message
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="settings">
+      <h2>⚙️ Configurações</h2>
+
+      <div className="settings-layout">
+        <aside className="settings-sidebar">
+          <button
+            type="button"
+            className={`settings-nav-item ${activeSection === 'credentials' ? 'active' : ''}`}
+            onClick={() => setActiveSection('credentials')}
+          >
+            🔐 Credenciais
+          </button>
+
+          {activeSection === 'credentials' && (
+            <div className="settings-subnav">
+              <button
+                type="button"
+                className={`settings-subnav-item ${activeSubSection === 'minio' ? 'active' : ''}`}
+                onClick={() => setActiveSubSection('minio')}
+              >
+                📦 Credenciais Minio
+              </button>
+            </div>
+          )}
+        </aside>
+
+        <section className="settings-content">
+          {activeSection === 'credentials' && activeSubSection === 'minio' && (
+            <div className="settings-card">
+              <h3>📦 Credenciais Minio</h3>
+              <p className="settings-description">
+                Configure as credenciais utilizadas para acessar o servidor Minio responsável
+                pelo armazenamento de arquivos e mídias.
+              </p>
+
+              {status && (
+                <div className={`settings-alert ${status.type}`}>
+                  {status.message}
+                </div>
+              )}
+
+              <form className="settings-form" onSubmit={handleSubmit}>
+                <div className="form-group">
+                  <label htmlFor="accessKey">Access Key</label>
+                  <input
+                    id="accessKey"
+                    name="accessKey"
+                    type="text"
+                    value={formData.accessKey}
+                    onChange={handleInputChange}
+                    placeholder="Ex: MINIOACCESSKEY"
+                    required
+                  />
+                </div>
+
+                <div className="form-group">
+                  <label htmlFor="secretKey">Secret Key</label>
+                  <input
+                    id="secretKey"
+                    name="secretKey"
+                    type="password"
+                    value={formData.secretKey}
+                    onChange={handleInputChange}
+                    placeholder="Ex: ************"
+                    required
+                  />
+                </div>
+
+                <div className="form-group">
+                  <label htmlFor="bucket">Bucket</label>
+                  <input
+                    id="bucket"
+                    name="bucket"
+                    type="text"
+                    value={formData.bucket}
+                    onChange={handleInputChange}
+                    placeholder="Ex: whatsapp-media"
+                    required
+                  />
+                </div>
+
+                <div className="form-group">
+                  <label htmlFor="url">URL</label>
+                  <input
+                    id="url"
+                    name="url"
+                    type="url"
+                    value={formData.url}
+                    onChange={handleInputChange}
+                    placeholder="Ex: https://minio.seudominio.com"
+                    required
+                  />
+                </div>
+
+                <button type="submit" className="save-button" disabled={loading}>
+                  {loading ? 'Salvando...' : 'Salvar'}
+                </button>
+              </form>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default Settings;


### PR DESCRIPTION
## Summary
- add the Configurações entry to the main navigation and route the view to the new Settings screen
- implement the Settings component with secondary navigation and a Minio credentials form that posts to /api/settings/minio
- style the settings layout to match the existing dashboard aesthetics

## Testing
- yarn test --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68c8b169fb5c832f820ce7b9d61938ab