### PR TITLE
Add MinIO settings API and tabbed settings UI

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2400,3 +2400,158 @@ body {
 .close-qr-btn:hover {
   background: #c53030;
 }
+
+/* Settings */
+.settings {
+  background: white;
+  border-radius: 16px;
+  padding: 2rem;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+}
+
+.settings h2 {
+  color: #2d3748;
+  margin-bottom: 1.5rem;
+}
+
+
+.settings-tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.settings-tablist,
+.settings-subtablist {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.settings-tablist {
+  border-bottom: 1px solid #e2e8f0;
+  padding-bottom: 0.75rem;
+}
+
+.settings-subtablist {
+  border-bottom: 1px solid #edf2f7;
+  padding-bottom: 0.75rem;
+  margin-top: -0.5rem;
+}
+
+.settings-tab,
+.settings-subtab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.4rem;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: #4a5568;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.settings-tab:hover,
+.settings-subtab:hover {
+  background: rgba(102, 126, 234, 0.15);
+  color: #4c51bf;
+}
+
+.settings-tab.active,
+.settings-subtab.active {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  box-shadow: 0 12px 30px rgba(102, 126, 234, 0.35);
+}
+
+.settings-panel {
+  margin-top: 0.5rem;
+}
+
+.settings-card {
+  background: #f8fafc;
+  border-radius: 12px;
+  padding: 2rem;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.05);
+}
+
+.settings-card h3 {
+  color: #2d3748;
+  margin-bottom: 0.75rem;
+}
+
+.settings-description {
+  color: #64748b;
+  margin-bottom: 1.5rem;
+  line-height: 1.6;
+}
+
+.settings-alert {
+  padding: 1rem 1.25rem;
+  border-radius: 8px;
+  font-weight: 500;
+  margin-bottom: 1.5rem;
+}
+
+.settings-alert.success {
+  background: #f0fff4;
+  color: #22543d;
+  border: 1px solid #9ae6b4;
+}
+
+.settings-alert.error {
+  background: #fed7d7;
+  color: #c53030;
+  border: 1px solid #fc8181;
+}
+
+.settings-form {
+  display: grid;
+  gap: 1.5rem;
+  max-width: 500px;
+}
+
+.settings-form input {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.settings-form input:focus {
+  outline: none;
+  border-color: #667eea;
+  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.15);
+}
+
+.settings-description.loading {
+  color: #4c51bf;
+  font-style: italic;
+}
+
+.settings-form .save-button {
+  justify-self: flex-start;
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
+@media (max-width: 768px) {
+  .settings-tablist,
+  .settings-subtablist {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 0.75rem;
+  }
+
+  .settings-tab,
+  .settings-subtab {
+    flex: 0 0 auto;
+  }
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,7 @@ import axios from 'axios';
 import FlowEditor from './components/FlowEditor';
 import FlowList from './components/FlowList';
 import MessagesCenter from './components/MessagesCenter';
+import Settings from './components/Settings';
 import WhatsAppInstances from './components/WhatsAppInstances';
 
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
@@ -60,12 +61,19 @@ const Navigation = ({ currentView, onViewChange }) => {
           <span className="nav-icon">💬</span>
           <span>Mensagens</span>
         </button>
-        <button 
+        <button
           className={`nav-item ${currentView === 'instances' ? 'active' : ''}`}
           onClick={() => onViewChange('instances')}
         >
           <span className="nav-icon">📱</span>
           <span>Instâncias</span>
+        </button>
+        <button
+          className={`nav-item ${currentView === 'settings' ? 'active' : ''}`}
+          onClick={() => onViewChange('settings')}
+        >
+          <span className="nav-icon">⚙️</span>
+          <span>Configurações</span>
         </button>
       </div>
     </nav>
@@ -437,6 +445,10 @@ function App() {
 
           {currentView === 'instances' && (
             <WhatsAppInstances />
+          )}
+
+          {currentView === 'settings' && (
+            <Settings />
           )}
         </div>
       </main>

--- a/frontend/src/components/Settings.js
+++ b/frontend/src/components/Settings.js
@@ -1,0 +1,255 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
+const API = `${BACKEND_URL}/api`;
+
+const Settings = () => {
+  const [activeSection, setActiveSection] = useState('credentials');
+  const [activeSubSection, setActiveSubSection] = useState('minio');
+  const [formData, setFormData] = useState({
+    accessKey: '',
+    secretKey: '',
+    bucket: '',
+    url: ''
+  });
+  const [status, setStatus] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [loadingSettings, setLoadingSettings] = useState(true);
+
+  useEffect(() => {
+    const fetchSettings = async () => {
+      try {
+        const response = await axios.get(`${API}/settings/minio`);
+        const data = response.data || {};
+        setFormData({
+          accessKey: data.accessKey || '',
+          secretKey: data.secretKey || '',
+          bucket: data.bucket || '',
+          url: data.url || ''
+        });
+      } catch (error) {
+        console.error('Failed to load MinIO credentials:', error);
+        const message =
+          error.response?.data?.error ||
+          error.response?.data?.message ||
+          'Não foi possível carregar as credenciais salvas.';
+        setStatus({
+          type: 'error',
+          message
+        });
+      } finally {
+        setLoadingSettings(false);
+      }
+    };
+
+    fetchSettings();
+  }, []);
+
+  const handleInputChange = (event) => {
+    const { name, value } = event.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+    if (status?.type === 'success') {
+      setStatus(null);
+    }
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setLoading(true);
+    setStatus(null);
+
+    try {
+      const payload = {
+        accessKey: formData.accessKey.trim(),
+        secretKey: formData.secretKey.trim(),
+        bucket: formData.bucket.trim(),
+        url: formData.url.trim()
+      };
+
+      if (Object.values(payload).some((value) => !value)) {
+        setStatus({
+          type: 'error',
+          message: 'Preencha todos os campos obrigatórios antes de salvar.'
+        });
+        return;
+      }
+
+      const response = await axios.post(`${API}/settings/minio`, payload);
+      const responseData = response.data || {};
+
+      setStatus({
+        type: 'success',
+        message:
+          responseData.message || 'Credenciais salvas com sucesso!'
+      });
+
+      if (responseData.settings) {
+        setFormData({
+          accessKey: responseData.settings.accessKey ?? payload.accessKey,
+          secretKey: responseData.settings.secretKey ?? payload.secretKey,
+          bucket: responseData.settings.bucket ?? payload.bucket,
+          url: responseData.settings.url ?? payload.url
+        });
+      }
+    } catch (error) {
+      const message =
+        error.response?.data?.message ||
+        error.response?.data?.error ||
+        'Não foi possível salvar as credenciais. Tente novamente.';
+      setStatus({
+        type: 'error',
+        message
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="settings">
+      <h2>⚙️ Configurações</h2>
+      <div className="settings-tabs">
+        <div
+          className="settings-tablist"
+          role="tablist"
+          aria-label="Categorias de configurações"
+        >
+          <button
+            type="button"
+            role="tab"
+            id="settings-tab-credentials"
+            aria-selected={activeSection === 'credentials'}
+            aria-controls="settings-panel-credentials"
+            className={`settings-tab ${activeSection === 'credentials' ? 'active' : ''}`}
+            onClick={() => {
+              setActiveSection('credentials');
+              setStatus(null);
+            }}
+          >
+            🔐 Credenciais
+          </button>
+        </div>
+
+        {activeSection === 'credentials' && (
+          <>
+            <div
+              className="settings-subtablist"
+              role="tablist"
+              aria-label="Opções de credenciais"
+            >
+              <button
+                type="button"
+                role="tab"
+                id="settings-subtab-minio"
+                aria-selected={activeSubSection === 'minio'}
+                aria-controls="settings-panel-minio"
+                className={`settings-subtab ${activeSubSection === 'minio' ? 'active' : ''}`}
+                onClick={() => setActiveSubSection('minio')}
+              >
+                📦 Credenciais Minio
+              </button>
+            </div>
+
+            {activeSubSection === 'minio' && (
+              <div
+                className="settings-card settings-panel"
+                role="tabpanel"
+                id="settings-panel-minio"
+                aria-labelledby="settings-subtab-minio"
+              >
+                <h3>📦 Credenciais Minio</h3>
+                <p className="settings-description">
+                  Configure as credenciais utilizadas para acessar o servidor Minio responsável
+                  pelo armazenamento de arquivos e mídias.
+                </p>
+
+                {status && (
+                  <div className={`settings-alert ${status.type}`}>
+                    {status.message}
+                  </div>
+                )}
+
+                {loadingSettings ? (
+                  <p className="settings-description loading">Carregando credenciais...</p>
+                ) : (
+                  <form className="settings-form" onSubmit={handleSubmit}>
+                    <div className="form-group">
+                      <label htmlFor="accessKey">Access Key</label>
+                      <input
+                        id="accessKey"
+                        name="accessKey"
+                        type="text"
+                        value={formData.accessKey}
+                        onChange={handleInputChange}
+                        placeholder="Ex: MINIOACCESSKEY"
+                        autoComplete="off"
+                        required
+                        disabled={loading}
+                      />
+                    </div>
+
+                    <div className="form-group">
+                      <label htmlFor="secretKey">Secret Key</label>
+                      <input
+                        id="secretKey"
+                        name="secretKey"
+                        type="password"
+                        value={formData.secretKey}
+                        onChange={handleInputChange}
+                        placeholder="Ex: ************"
+                        autoComplete="new-password"
+                        required
+                        disabled={loading}
+                      />
+                    </div>
+
+                    <div className="form-group">
+                      <label htmlFor="bucket">Bucket</label>
+                      <input
+                        id="bucket"
+                        name="bucket"
+                        type="text"
+                        value={formData.bucket}
+                        onChange={handleInputChange}
+                        placeholder="Ex: whatsapp-media"
+                        autoComplete="off"
+                        required
+                        disabled={loading}
+                      />
+                    </div>
+
+                    <div className="form-group">
+                      <label htmlFor="url">URL</label>
+                      <input
+                        id="url"
+                        name="url"
+                        type="url"
+                        value={formData.url}
+                        onChange={handleInputChange}
+                        placeholder="Ex: https://minio.seudominio.com"
+                        autoComplete="off"
+                        required
+                        disabled={loading}
+                      />
+                    </div>
+
+                    <button
+                      type="submit"
+                      className="save-button"
+                      disabled={loading}
+                    >
+                      {loading ? 'Salvando...' : 'Salvar'}
+                    </button>
+                  </form>
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Settings;

--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -107,6 +107,39 @@ def _get_minio_public_base() -> str:
     return f"{scheme}://{_MINIO_ENDPOINT}"
 
 
+def update_minio_runtime_configuration(
+    *,
+    endpoint: Optional[str] = None,
+    access_key: Optional[str] = None,
+    secret_key: Optional[str] = None,
+    bucket: Optional[str] = None,
+    public_url: Optional[str] = None,
+) -> None:
+    """Atualiza as configurações do MinIO em tempo de execução."""
+
+    global MINIO_ENDPOINT_RAW, MINIO_ACCESS_KEY, MINIO_SECRET_KEY, MINIO_BUCKET, MINIO_PUBLIC_URL
+    global _MINIO_ENDPOINT, _MINIO_SECURE_DEFAULT, _MINIO_CLIENT
+
+    if endpoint is not None:
+        MINIO_ENDPOINT_RAW = endpoint or ""
+        _MINIO_ENDPOINT, _MINIO_SECURE_DEFAULT = _parse_minio_endpoint(MINIO_ENDPOINT_RAW)
+
+    if public_url is not None:
+        MINIO_PUBLIC_URL = public_url or None
+
+    if access_key is not None:
+        MINIO_ACCESS_KEY = access_key
+
+    if secret_key is not None:
+        MINIO_SECRET_KEY = secret_key
+
+    if bucket is not None:
+        MINIO_BUCKET = bucket
+
+    # Força recriação do cliente com as novas credenciais na próxima utilização
+    _MINIO_CLIENT = None
+
+
 def _ensure_minio_dependency():
     global Minio
     if Minio is not None:
@@ -6971,7 +7004,15 @@ def init_db():
     cursor.execute("PRAGMA cache_size = 1000")
     cursor.execute("PRAGMA temp_store = MEMORY")
     cursor.execute("PRAGMA mmap_size = 268435456")  # 256MB
-    
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS settings (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+    """)
+
     # Enhanced tables with better schema
     cursor.execute("""
         CREATE TABLE IF NOT EXISTS instances (
@@ -7105,7 +7146,28 @@ def init_db():
             FOREIGN KEY (campaign_id) REFERENCES campaigns (id) ON DELETE CASCADE
         )
     """)
-    
+
+    try:
+        cursor.execute(
+            "SELECT key, value FROM settings WHERE key LIKE 'minio.%'"
+        )
+        stored_settings = cursor.fetchall()
+        if stored_settings:
+            settings_map = {row[0]: row[1] for row in stored_settings}
+            update_minio_runtime_configuration(
+                endpoint=settings_map.get("minio.url"),
+                public_url=settings_map.get("minio.url"),
+                access_key=settings_map.get("minio.access_key"),
+                secret_key=settings_map.get("minio.secret_key"),
+                bucket=settings_map.get("minio.bucket"),
+            )
+            logger.info("⚙️ Credenciais do MinIO carregadas do banco de dados.")
+    except sqlite3.Error as exc:
+        logger.warning(
+            "⚠️ Não foi possível carregar as configurações do MinIO salvas: %s",
+            exc,
+        )
+
     conn.commit()
     conn.close()
     print("✅ Banco de dados inicializado com suporte para Campanhas e WebSocket")
@@ -8272,6 +8334,8 @@ class WhatsFlowRealHandler(BaseHTTPRequestHandler):
             self.handle_get_webhooks()
         elif self.path == '/api/scheduled-messages':
             self.handle_get_scheduled_messages()
+        elif self.path == '/api/settings/minio':
+            self.handle_get_minio_settings()
         else:
             self.send_error(404, "Not Found")
     
@@ -8329,6 +8393,8 @@ class WhatsFlowRealHandler(BaseHTTPRequestHandler):
             self.handle_send_webhook()
         elif self.path == '/api/scheduled-messages':
             self.handle_create_scheduled_message()
+        elif self.path == '/api/settings/minio':
+            self.handle_update_minio_settings()
         else:
             self.send_error(404, "Not Found")
     
@@ -8367,11 +8433,18 @@ class WhatsFlowRealHandler(BaseHTTPRequestHandler):
             self.send_error(404, "Not Found")
     
     def send_html_response(self, html_content):
-        self.send_response(200)
-        self.send_header('Content-type', 'text/html; charset=utf-8')
-        self.send_header('Cache-Control', 'no-cache')
-        self.end_headers()
-        self.wfile.write(html_content.encode('utf-8'))
+        try:
+            self.send_response(200)
+            self.send_header('Content-type', 'text/html; charset=utf-8')
+            self.send_header('Cache-Control', 'no-cache')
+            self.end_headers()
+            self.wfile.write(html_content.encode('utf-8'))
+        except (BrokenPipeError, ConnectionResetError):
+            logger.warning(
+                "⚠️ Cliente encerrou a conexão antes de receber a resposta HTML."
+            )
+        except Exception as exc:
+            logger.exception("❌ Erro ao enviar resposta HTML: %s", exc)
     
     def send_json_response(self, data, status_code=200):
         self.send_response(status_code)
@@ -8382,7 +8455,143 @@ class WhatsFlowRealHandler(BaseHTTPRequestHandler):
         self.end_headers()
         json_data = json.dumps(data, ensure_ascii=False, indent=2)
         self.wfile.write(json_data.encode('utf-8'))
-    
+
+    def handle_get_minio_settings(self):
+        try:
+            with sqlite3.connect(DB_FILE, timeout=30) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    "SELECT key, value FROM settings WHERE key LIKE 'minio.%'"
+                )
+                rows = cursor.fetchall()
+        except sqlite3.Error as exc:
+            logger.error("❌ Erro ao carregar configurações do MinIO: %s", exc)
+            self.send_json_response(
+                {"error": "Não foi possível carregar as credenciais do MinIO."},
+                500,
+            )
+            return
+
+        settings_map = {row[0]: row[1] for row in rows}
+        response_data = {
+            "accessKey": settings_map.get("minio.access_key", MINIO_ACCESS_KEY or ""),
+            "secretKey": settings_map.get("minio.secret_key", MINIO_SECRET_KEY or ""),
+            "bucket": settings_map.get("minio.bucket", MINIO_BUCKET or ""),
+            "url": settings_map.get("minio.url", MINIO_ENDPOINT_RAW or ""),
+        }
+
+        self.send_json_response(response_data)
+
+    def handle_update_minio_settings(self):
+        try:
+            content_length = int(self.headers.get('Content-Length', 0))
+        except (TypeError, ValueError):
+            self.send_json_response({"error": "Requisição inválida."}, 400)
+            return
+
+        if content_length <= 0:
+            self.send_json_response({"error": "Nenhum dado enviado."}, 400)
+            return
+
+        try:
+            payload = self.rfile.read(content_length)
+            data = json.loads(payload.decode('utf-8'))
+        except json.JSONDecodeError:
+            self.send_json_response({"error": "JSON inválido."}, 400)
+            return
+
+        required_fields = ["accessKey", "secretKey", "bucket", "url"]
+        missing_fields = [
+            field for field in required_fields
+            if not str(data.get(field, "")).strip()
+        ]
+        if missing_fields:
+            self.send_json_response(
+                {
+                    "error": (
+                        "Os campos obrigatórios não foram informados: "
+                        + ", ".join(missing_fields)
+                    )
+                },
+                400,
+            )
+            return
+
+        access_key = data["accessKey"].strip()
+        secret_key = data["secretKey"].strip()
+        bucket = data["bucket"].strip()
+        url = data["url"].strip()
+        if len(url) > 1:
+            url = url.rstrip('/')
+
+        timestamp = datetime.now(timezone.utc).isoformat()
+
+        try:
+            with sqlite3.connect(DB_FILE, timeout=30) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    """
+                    INSERT INTO settings (key, value, updated_at)
+                    VALUES (?, ?, ?)
+                    ON CONFLICT(key) DO UPDATE SET value=excluded.value, updated_at=excluded.updated_at
+                    """,
+                    ("minio.access_key", access_key, timestamp),
+                )
+                cursor.execute(
+                    """
+                    INSERT INTO settings (key, value, updated_at)
+                    VALUES (?, ?, ?)
+                    ON CONFLICT(key) DO UPDATE SET value=excluded.value, updated_at=excluded.updated_at
+                    """,
+                    ("minio.secret_key", secret_key, timestamp),
+                )
+                cursor.execute(
+                    """
+                    INSERT INTO settings (key, value, updated_at)
+                    VALUES (?, ?, ?)
+                    ON CONFLICT(key) DO UPDATE SET value=excluded.value, updated_at=excluded.updated_at
+                    """,
+                    ("minio.bucket", bucket, timestamp),
+                )
+                cursor.execute(
+                    """
+                    INSERT INTO settings (key, value, updated_at)
+                    VALUES (?, ?, ?)
+                    ON CONFLICT(key) DO UPDATE SET value=excluded.value, updated_at=excluded.updated_at
+                    """,
+                    ("minio.url", url, timestamp),
+                )
+                conn.commit()
+        except sqlite3.Error as exc:
+            logger.exception("❌ Erro ao salvar credenciais do MinIO: %s", exc)
+            self.send_json_response(
+                {"error": "Não foi possível salvar as credenciais do MinIO."},
+                500,
+            )
+            return
+
+        update_minio_runtime_configuration(
+            endpoint=url,
+            public_url=url,
+            access_key=access_key,
+            secret_key=secret_key,
+            bucket=bucket,
+        )
+        logger.info("✅ Credenciais do MinIO atualizadas via API.")
+
+        self.send_json_response(
+            {
+                "success": True,
+                "message": "Credenciais do MinIO atualizadas com sucesso.",
+                "settings": {
+                    "accessKey": access_key,
+                    "secretKey": secret_key,
+                    "bucket": bucket,
+                    "url": url,
+                },
+            }
+        )
+
     def handle_get_instances(self):
         try:
             with sqlite3.connect(DB_FILE, timeout=30) as conn:


### PR DESCRIPTION
## Summary
- add MinIO settings persistence with GET/POST endpoints and runtime reload support in the real server
- load saved MinIO credentials on the frontend and present them in a tabbed settings experience with improved UX feedback
- harden the HTML response handling to avoid noisy BrokenPipeError traces when clients disconnect

## Testing
- yarn test --watchAll=false --passWithNoTests
- python -m py_compile whatsflow-real.py

------
https://chatgpt.com/codex/tasks/task_e_68c8b169fb5c832f820ce7b9d61938ab