### PR TITLE
Handle automatic minio installation

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -276,11 +276,23 @@ def _ensure_minio_dependency():
     try:
         Minio = importlib.import_module("minio").Minio
         return Minio
-    except ModuleNotFoundError as exc:
-        raise RuntimeError(
-            "Biblioteca 'minio' não encontrada. "
-            "Instale-a manualmente executando: python3 -m pip install minio"
-        ) from exc
+    except ModuleNotFoundError:
+        try:
+            subprocess.check_call([sys.executable, "-m", "pip", "install", "minio"])
+        except Exception as install_exc:
+            raise RuntimeError(
+                "Não foi possível instalar automaticamente a biblioteca 'minio'. "
+                "Instale-a manualmente executando: python3 -m pip install minio"
+            ) from install_exc
+
+        try:
+            Minio = importlib.import_module("minio").Minio
+            return Minio
+        except ModuleNotFoundError as exc:
+            raise RuntimeError(
+                "Biblioteca 'minio' não pôde ser importada mesmo após tentativa de instalação automática. "
+                "Instale-a manualmente executando: python3 -m pip install minio"
+            ) from exc
 
 
 def get_minio_client():


### PR DESCRIPTION
## Summary
- attempt to install the `minio` package automatically when it is missing in `whatsflow-real`
- retry the import after installation and raise a clear error if it still fails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8ca0c20a4832f813cb040f926b4b6