### PR TITLE
Improve MinIO dependency installation flow

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -277,12 +277,34 @@ def _ensure_minio_dependency():
         Minio = importlib.import_module("minio").Minio
         return Minio
     except ModuleNotFoundError:
+        print("📦 Instalando dependência 'minio' (necessária para integração com MinIO)...")
         try:
-            subprocess.check_call([sys.executable, "-m", "pip", "install", "minio"])
+            subprocess.check_call(
+                [sys.executable, "-m", "pip", "install", "--user", "minio"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except subprocess.CalledProcessError as install_exc:
+            stderr_output = ""
+            if install_exc.stderr:
+                stderr_output = install_exc.stderr.decode(errors="ignore")
+            elif install_exc.output:
+                stderr_output = install_exc.output.decode(errors="ignore")
+
+            if "externally managed environment" in stderr_output.lower():
+                raise RuntimeError(
+                    "O ambiente Python é gerenciado externamente (PEP 668). "
+                    "Crie um ambiente virtual ou execute o comando novamente com --break-system-packages."
+                ) from install_exc
+
+            raise RuntimeError(
+                "Não foi possível instalar automaticamente a biblioteca 'minio'. "
+                "Instale-a manualmente executando: python3 -m pip install --user minio"
+            ) from install_exc
         except Exception as install_exc:
             raise RuntimeError(
                 "Não foi possível instalar automaticamente a biblioteca 'minio'. "
-                "Instale-a manualmente executando: python3 -m pip install minio"
+                "Instale-a manualmente executando: python3 -m pip install --user minio"
             ) from install_exc
 
         try:
@@ -291,7 +313,7 @@ def _ensure_minio_dependency():
         except ModuleNotFoundError as exc:
             raise RuntimeError(
                 "Biblioteca 'minio' não pôde ser importada mesmo após tentativa de instalação automática. "
-                "Instale-a manualmente executando: python3 -m pip install minio"
+                "Instale-a manualmente executando: python3 -m pip install --user minio"
             ) from exc
 
 


### PR DESCRIPTION
## Summary
- install the MinIO client dependency with ``pip --user`` and capture installation errors
- surface a dedicated hint when the environment is externally managed (PEP 668)
- keep raising actionable guidance when the library still cannot be imported

## Testing
- python -m compileall whatsflow-real.py

------
https://chatgpt.com/codex/tasks/task_e_68c8d070307c832fa6907259c10badd1