### PR TITLE
Add campaign media manager and improve MinIO uploads

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -28,6 +28,7 @@ import pytz
 import io
 import importlib
 import cgi
+import mimetypes
 
 warnings.filterwarnings("ignore", category=DeprecationWarning, module="cgi")
 
@@ -71,7 +72,9 @@ DB_FILE = "whatsflow.db"
 PORT = 8889
 WEBSOCKET_PORT = 8890
 
-MINIO_ENDPOINT_RAW = os.environ.get("MINIO_ENDPOINT", "http://localhost:9000")
+DEFAULT_MINIO_ENDPOINT = "https://minio.auto-atendimento.digital"
+
+MINIO_ENDPOINT_RAW = os.environ.get("MINIO_ENDPOINT", DEFAULT_MINIO_ENDPOINT)
 MINIO_ACCESS_KEY = os.environ.get("MINIO_ACCESS_KEY", "03CnLEOqVp65uzt9dbpp")
 MINIO_SECRET_KEY = os.environ.get("MINIO_SECRET_KEY", "oR5eC5wlm2cVE93xNbhLdLpxsm6eapxY43nolmf4")
 MINIO_BUCKET = os.environ.get("MINIO_BUCKET", "meu-bucket")
@@ -80,6 +83,8 @@ _MINIO_CLIENT = None
 _MINIO_ENDPOINT = None
 _MINIO_SECURE_DEFAULT = False
 Minio = None
+_MINIO_POLICY_CHECKED = False
+_MINIO_PRESIGNED_WARNING = False
 
 
 def ensure_minio_credentials_table() -> None:
@@ -120,16 +125,30 @@ def _fetch_minio_credentials_from_db() -> Optional[Dict[str, str]]:
     return None
 
 
+def _compute_minio_host(endpoint: str) -> Tuple[str, bool]:
+    parsed = urllib.parse.urlparse(endpoint)
+    host = parsed.netloc or parsed.path
+    if not host:
+        host = "localhost:9000"
+    secure = parsed.scheme.lower() == "https"
+    return host, secure
+
+
+DEFAULT_MINIO_HOST, DEFAULT_MINIO_SECURE = _compute_minio_host(DEFAULT_MINIO_ENDPOINT)
+
+
 def _parse_minio_endpoint(endpoint: str) -> Tuple[str, bool]:
     if not endpoint:
-        return "localhost:9000", False
+        return DEFAULT_MINIO_HOST, DEFAULT_MINIO_SECURE
     secure = False
     cleaned = endpoint
     if "://" in endpoint:
         parsed = urllib.parse.urlparse(endpoint)
         secure = parsed.scheme.lower() == "https"
         cleaned = parsed.netloc or parsed.path
-    return cleaned or "localhost:9000", secure
+    if not cleaned:
+        return DEFAULT_MINIO_HOST, secure or DEFAULT_MINIO_SECURE
+    return cleaned, secure
 
 
 def _load_minio_configuration() -> Tuple[str, str, str, str, Optional[str]]:
@@ -140,7 +159,7 @@ def _load_minio_configuration() -> Tuple[str, str, str, str, Optional[str]]:
         "MINIO_SECRET_KEY", "oR5eC5wlm2cVE93xNbhLdLpxsm6eapxY43nolmf4"
     )
     bucket = os.environ.get("MINIO_BUCKET", "meu-bucket")
-    endpoint_raw = os.environ.get("MINIO_ENDPOINT", "http://localhost:9000")
+    endpoint_raw = os.environ.get("MINIO_ENDPOINT", DEFAULT_MINIO_ENDPOINT)
     public_url = os.environ.get("MINIO_PUBLIC_URL")
 
     stored = _fetch_minio_credentials_from_db()
@@ -260,11 +279,74 @@ def _ensure_minio_dependency():
     try:
         Minio = importlib.import_module("minio").Minio
         return Minio
-    except ModuleNotFoundError as exc:
-        raise RuntimeError(
-            "Biblioteca 'minio' não encontrada. "
-            "Instale-a manualmente executando: python3 -m pip install minio"
-        ) from exc
+    except ModuleNotFoundError:
+        print("📦 Instalando dependência 'minio' automaticamente...")
+        installation_succeeded = False
+        pep668_detected = False
+        last_error_output = ""
+        install_variants = [
+            [],
+            ["--user"],
+        ]
+
+        for extra_args in install_variants:
+            cmd = [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                *extra_args,
+                "minio",
+            ]
+            cmd_display = " ".join(cmd)
+            try:
+                subprocess.run(cmd, check=True, capture_output=True, text=True)
+                installation_succeeded = True
+                break
+            except subprocess.CalledProcessError as exc:
+                output = "\n".join(
+                    list(
+                        filter(
+                            None,
+                            [
+                                (exc.stdout or "").strip(),
+                                (exc.stderr or "").strip(),
+                            ],
+                        )
+                    )
+                )
+                last_error_output = output
+                if output:
+                    print(f"⚠️ Falha ao executar '{cmd_display}':\n{output}\n")
+                if "externally-managed-environment" in output or "externally managed environment" in output:
+                    pep668_detected = True
+            except FileNotFoundError as exc:
+                raise RuntimeError(
+                    "Não foi possível localizar o executável do pip para instalar 'minio'."
+                ) from exc
+
+        if not installation_succeeded:
+            message = "Não foi possível instalar a biblioteca 'minio'."
+            if pep668_detected:
+                message += (
+                    " O Python deste sistema é gerenciado externamente (PEP 668). "
+                    "Crie um ambiente virtual com 'python3 -m venv .venv' e execute novamente o script, "
+                    "ou rode 'python3 -m pip install --break-system-packages minio'."
+                )
+            else:
+                message += " Instale-a manualmente executando: python3 -m pip install minio"
+            if last_error_output:
+                message += f"\nSaída do pip:\n{last_error_output}"
+            raise RuntimeError(message)
+
+        try:
+            Minio = importlib.import_module("minio").Minio
+            return Minio
+        except ModuleNotFoundError as exc:  # pragma: no cover - fallback inesperado
+            raise RuntimeError(
+                "A biblioteca 'minio' ainda não pôde ser carregada após a instalação automática. "
+                "Verifique o ambiente Python e tente novamente."
+            ) from exc
 
 
 def get_minio_client():
@@ -328,6 +410,34 @@ def resolve_baileys_url() -> str:
 API_BASE_URL = resolve_baileys_url()
 
 
+def _apply_public_read_policy(client) -> None:
+    global _MINIO_POLICY_CHECKED
+    if _MINIO_POLICY_CHECKED:
+        return
+
+    _MINIO_POLICY_CHECKED = True
+    policy_document = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": ["*"]},
+                "Action": ["s3:GetObject"],
+                "Resource": [f"arn:aws:s3:::{MINIO_BUCKET}/*"],
+            }
+        ],
+    }
+
+    try:
+        client.set_bucket_policy(MINIO_BUCKET, json.dumps(policy_document))
+    except Exception as exc:  # pragma: no cover - dependente de permissões externas
+        logging.getLogger(__name__).warning(
+            "Não foi possível aplicar política pública ao bucket '%s': %s",
+            MINIO_BUCKET,
+            exc,
+        )
+
+
 def ensure_minio_bucket(client=None):
     client = client or get_minio_client()
     try:
@@ -337,7 +447,33 @@ def ensure_minio_bucket(client=None):
         raise RuntimeError(
             f"Não foi possível preparar o bucket '{MINIO_BUCKET}' no MinIO: {exc}"
         ) from exc
+    _apply_public_read_policy(client)
     return client
+
+
+def _generate_minio_file_url(client, object_name: str) -> str:
+    global _MINIO_PRESIGNED_WARNING
+
+    if MINIO_PUBLIC_URL:
+        base = MINIO_PUBLIC_URL.rstrip("/")
+        return f"{base}/{MINIO_BUCKET}/{object_name}"
+
+    try:
+        return client.presigned_get_object(
+            MINIO_BUCKET,
+            object_name,
+            expires=timedelta(days=7),
+        )
+    except Exception as exc:  # pragma: no cover - depende da configuração externa
+        if not _MINIO_PRESIGNED_WARNING:
+            logging.getLogger(__name__).warning(
+                "Não foi possível gerar URL temporária para o objeto '%s': %s",
+                object_name,
+                exc,
+            )
+            _MINIO_PRESIGNED_WARNING = True
+
+    return f"{_get_minio_public_base()}/{MINIO_BUCKET}/{object_name}"
 
 
 def upload_to_minio(filename: str, data: bytes) -> str:
@@ -345,11 +481,18 @@ def upload_to_minio(filename: str, data: bytes) -> str:
     name = filename or "arquivo"
     object_name = f"{int(time.time() * 1000)}{os.path.splitext(name)[1]}"
     data_stream = io.BytesIO(data)
+    content_type = mimetypes.guess_type(name)[0] or "application/octet-stream"
     try:
-        client.put_object(MINIO_BUCKET, object_name, data_stream, len(data))
+        client.put_object(
+            MINIO_BUCKET,
+            object_name,
+            data_stream,
+            len(data),
+            content_type=content_type,
+        )
     except Exception as exc:
         raise RuntimeError(f"Falha ao enviar arquivo para o MinIO: {exc}") from exc
-    return f"{_get_minio_public_base()}/{MINIO_BUCKET}/{object_name}"
+    return _generate_minio_file_url(client, object_name)
 
 # WebSocket clients management
 if WEBSOCKETS_AVAILABLE:
@@ -3586,6 +3729,7 @@ HTML_APP = '''<!DOCTYPE html>
                     <option value="image">🖼️ Imagem</option>
                     <option value="audio">🎵 Áudio</option>
                     <option value="video">🎥 Vídeo</option>
+                    <option value="document">📄 Documento</option>
                 </select>
             </div>
             
@@ -3755,6 +3899,9 @@ HTML_APP = '''<!DOCTYPE html>
                 <button class="btn btn-secondary campaign-nav-btn active" onclick="showCampaignTab('groups')" id="groupsTab">
                     👥 Grupos
                 </button>
+                <button class="btn btn-secondary campaign-nav-btn" onclick="showCampaignTab('media')" id="mediaTab">
+                    🖼️ Mídia
+                </button>
                 <button class="btn btn-secondary campaign-nav-btn" onclick="showCampaignTab('schedule')" id="scheduleTab">
                     ⏰ Programar
                 </button>
@@ -3762,7 +3909,7 @@ HTML_APP = '''<!DOCTYPE html>
                     📋 Ver Programações
                 </button>
             </div>
-            
+
             <!-- Groups Tab -->
             <div id="campaignGroupsTab" class="campaign-tab active">
                 <div style="margin-bottom: 15px;">
@@ -3790,7 +3937,50 @@ HTML_APP = '''<!DOCTYPE html>
                     </div>
                 </div>
             </div>
-            
+
+            <!-- Media Tab -->
+            <div id="campaignMediaTab" class="campaign-tab" style="display: none;">
+                <div style="margin-bottom: 12px; color: #475569; font-size: 0.95rem;">
+                    <p>Envie arquivos para o MinIO e gere automaticamente a <code>mediaUrl</code> usada pelo Baileys nas campanhas em grupo.</p>
+                </div>
+                <input type="file" id="campaignMediaFile" style="display:none" accept="image/*,video/*,audio/*,application/*"
+                       onchange="uploadMediaFile(this.files[0], 'campaignMediaUrl', 'campaignMediaUploadStatus')">
+                <div style="display: flex; flex-wrap: wrap; gap: 10px; align-items: center; margin-bottom: 10px;">
+                    <button type="button" class="btn btn-secondary" onclick="document.getElementById('campaignMediaFile').click()">
+                        📁 Selecionar Arquivo
+                    </button>
+                    <span style="font-size: 0.85rem; color: #64748b;">O link será preenchido automaticamente após o envio.</span>
+                </div>
+                <p id="campaignMediaUploadStatus" style="margin-bottom: 15px; font-size: 0.85rem; color: #64748b;"></p>
+                <div style="margin-bottom: 15px;">
+                    <label style="display: block; margin-bottom: 5px; font-weight: 500;">URL da Mídia (mediaUrl)</label>
+                    <input type="text" id="campaignMediaUrl" class="form-input"
+                           placeholder="A URL gerada aparecerá aqui automaticamente"
+                           oninput="updateCampaignMediaPreview()">
+                </div>
+                <div style="margin-bottom: 15px;">
+                    <label style="display: block; margin-bottom: 5px; font-weight: 500;">Tipo da Mídia</label>
+                    <select id="campaignMediaType" class="form-input" onchange="updateCampaignMediaPreview()">
+                        <option value="image">🖼️ Imagem</option>
+                        <option value="video">🎥 Vídeo</option>
+                        <option value="audio">🎵 Áudio</option>
+                        <option value="document">📄 Documento</option>
+                    </select>
+                </div>
+                <div style="margin-bottom: 15px;">
+                    <label style="display: block; margin-bottom: 5px; font-weight: 500;">Legenda/Texto (opcional)</label>
+                    <textarea id="campaignMediaCaption" class="form-input"
+                              placeholder="Adicione uma legenda para acompanhar a mídia..."
+                              style="height: 70px; resize: vertical;"></textarea>
+                </div>
+                <div id="campaignMediaPreview" style="margin-bottom: 20px; display: none;"></div>
+                <div style="display: flex; flex-wrap: wrap; gap: 10px;">
+                    <button type="button" class="btn btn-primary" onclick="applyCampaignMediaToSchedule()">Usar no agendamento</button>
+                    <button type="button" class="btn btn-secondary" onclick="copyCampaignMediaUrl()">Copiar URL</button>
+                    <button type="button" class="btn" onclick="clearCampaignMediaSelection()">Limpar</button>
+                </div>
+            </div>
+
             <!-- Schedule Tab -->
             <div id="campaignScheduleTab" class="campaign-tab" style="display: none;">
                 <div style="text-align: center; padding: 20px;">
@@ -3822,6 +4012,7 @@ HTML_APP = '''<!DOCTYPE html>
         let statusPollingInterval = null;
         let minioSettingsLoaded = false;
         let minioSettingsLoading = false;
+        let currentCampaignMediaUrl = '';
 
         function selectSettingsTab(tabName) {
             const tabButtons = document.querySelectorAll('[data-settings-tab]');
@@ -4974,6 +5165,9 @@ HTML_APP = '''<!DOCTYPE html>
                     targetInput.dispatchEvent(new Event('change', { bubbles: true }));
                     if (targetFieldId === 'scheduleMediaUrl') {
                         previewMedia();
+                    } else if (targetFieldId === 'campaignMediaUrl') {
+                        currentCampaignMediaUrl = data.url;
+                        updateCampaignMediaPreview();
                     }
                 }
 
@@ -4990,6 +5184,9 @@ HTML_APP = '''<!DOCTYPE html>
                 } else if (targetFieldId === 'scheduleMediaUrl') {
                     const scheduleFileInput = document.getElementById('scheduleMediaFile');
                     if (scheduleFileInput) scheduleFileInput.value = '';
+                } else if (targetFieldId === 'campaignMediaUrl') {
+                    const campaignFileInput = document.getElementById('campaignMediaFile');
+                    if (campaignFileInput) campaignFileInput.value = '';
                 }
             } catch (err) {
                 console.error(err);
@@ -6647,8 +6844,15 @@ HTML_APP = '''<!DOCTYPE html>
                         <div style="display: none; color: #ef4444; padding: 20px;">❌ Não foi possível carregar o áudio</div>
                     </div>
                 `;
+            } else if (messageType === 'document') {
+                previewHtml = `
+                    <div style="background: #f1f5f9; padding: 16px; border-radius: 6px;">
+                        <div style="font-weight: 600; margin-bottom: 6px;">📄 Documento pronto para envio</div>
+                        <a href="${url}" target="_blank" style="color: #0369a1; word-break: break-all;">${url}</a>
+                    </div>
+                `;
             }
-            
+
             preview.innerHTML = previewHtml;
             preview.style.display = 'block';
         }
@@ -7172,23 +7376,26 @@ HTML_APP = '''<!DOCTYPE html>
             selectedCampaignInstanceId = '';
             document.getElementById('manageCampaignTitle').textContent = `🎯 ${campaignName}`;
             document.getElementById('manageCampaignModal').style.display = 'flex';
-            
+
             // Load all instances for group selection
             loadCampaignInstancesForGroups();
-            
+
             // Load existing campaign groups
             loadExistingCampaignGroups(campaignId);
-            
+
+            resetCampaignMediaManager();
+
             // Show groups tab by default
             showCampaignTab('groups');
         }
-        
+
         // Hide campaign management modal
         function hideCampaignModal() {
             document.getElementById('manageCampaignModal').style.display = 'none';
             currentCampaignId = null;
             selectedCampaignGroups = [];
             selectedCampaignInstanceId = '';
+            resetCampaignMediaManager();
         }
         
         // Show campaign tab
@@ -7214,7 +7421,178 @@ HTML_APP = '''<!DOCTYPE html>
                 loadCampaignScheduledMessages();
             }
         }
-        
+
+        function resetCampaignMediaManager() {
+            currentCampaignMediaUrl = '';
+            const urlInput = document.getElementById('campaignMediaUrl');
+            if (urlInput) {
+                urlInput.value = '';
+            }
+            const captionInput = document.getElementById('campaignMediaCaption');
+            if (captionInput) {
+                captionInput.value = '';
+            }
+            const typeSelect = document.getElementById('campaignMediaType');
+            if (typeSelect) {
+                typeSelect.value = 'image';
+            }
+            const statusElement = document.getElementById('campaignMediaUploadStatus');
+            if (statusElement) {
+                statusElement.textContent = '';
+                statusElement.style.color = '#64748b';
+            }
+            const preview = document.getElementById('campaignMediaPreview');
+            if (preview) {
+                preview.innerHTML = '';
+                preview.style.display = 'none';
+            }
+            const fileInput = document.getElementById('campaignMediaFile');
+            if (fileInput) {
+                fileInput.value = '';
+            }
+        }
+
+        function updateCampaignMediaPreview() {
+            const urlInput = document.getElementById('campaignMediaUrl');
+            const preview = document.getElementById('campaignMediaPreview');
+            const typeSelect = document.getElementById('campaignMediaType');
+
+            if (!preview || !typeSelect) {
+                return;
+            }
+
+            const url = (urlInput && urlInput.value ? urlInput.value : '').trim();
+            const type = typeSelect.value || 'image';
+
+            if (!url) {
+                preview.innerHTML = '';
+                preview.style.display = 'none';
+                currentCampaignMediaUrl = '';
+                return;
+            }
+
+            currentCampaignMediaUrl = url;
+
+            let previewHtml = '';
+
+            if (type === 'image') {
+                previewHtml = `
+                    <div style="text-align: center;">
+                        <img src="${url}" alt="Preview" style="max-width: 100%; max-height: 220px; border-radius: 6px;"
+                             onerror="this.style.display='none'; this.nextElementSibling.style.display='block';">
+                        <div style="display: none; color: #ef4444; padding: 20px;">❌ Não foi possível carregar a imagem</div>
+                    </div>
+                `;
+            } else if (type === 'video') {
+                previewHtml = `
+                    <div style="text-align: center;">
+                        <video controls style="max-width: 100%; max-height: 220px; border-radius: 6px;"
+                               onerror="this.style.display='none'; this.nextElementSibling.style.display='block';">
+                            <source src="${url}">
+                            Seu navegador não suporta vídeos.
+                        </video>
+                        <div style="display: none; color: #ef4444; padding: 20px;">❌ Não foi possível carregar o vídeo</div>
+                    </div>
+                `;
+            } else if (type === 'audio') {
+                previewHtml = `
+                    <div style="text-align: center;">
+                        <audio controls style="width: 100%;"
+                               onerror="this.style.display='none'; this.nextElementSibling.style.display='block';">
+                            <source src="${url}">
+                            Seu navegador não suporta áudio.
+                        </audio>
+                        <div style="display: none; color: #ef4444; padding: 20px;">❌ Não foi possível carregar o áudio</div>
+                    </div>
+                `;
+            } else {
+                previewHtml = `
+                    <div style="background: #f1f5f9; padding: 16px; border-radius: 6px;">
+                        <div style="font-weight: 600; margin-bottom: 6px;">📄 Documento disponível</div>
+                        <a href="${url}" target="_blank" style="color: #0369a1; word-break: break-all;">${url}</a>
+                    </div>
+                `;
+            }
+
+            preview.innerHTML = previewHtml;
+            preview.style.display = 'block';
+        }
+
+        function applyCampaignMediaToSchedule() {
+            const urlInput = document.getElementById('campaignMediaUrl');
+            const typeSelect = document.getElementById('campaignMediaType');
+            const captionInput = document.getElementById('campaignMediaCaption');
+            const url = (urlInput && urlInput.value ? urlInput.value : '').trim();
+
+            if (!url) {
+                alert('❌ Gere ou informe uma URL de mídia primeiro.');
+                return;
+            }
+
+            const scheduleTypeSelect = document.getElementById('scheduleMessageType');
+            const scheduleUrlInput = document.getElementById('scheduleMediaUrl');
+            const scheduleCaption = document.getElementById('scheduleMediaCaption');
+            const uploadStatus = document.getElementById('scheduleMediaUploadStatus');
+
+            if (scheduleTypeSelect) {
+                const mediaType = typeSelect ? typeSelect.value : 'image';
+                if (![...scheduleTypeSelect.options].some(opt => opt.value === mediaType)) {
+                    const option = document.createElement('option');
+                    option.value = mediaType;
+                    option.textContent = '📄 Documento';
+                    scheduleTypeSelect.appendChild(option);
+                }
+                scheduleTypeSelect.value = mediaType;
+                handleMessageTypeChange();
+            }
+
+            if (scheduleUrlInput) {
+                scheduleUrlInput.value = url;
+                scheduleUrlInput.dispatchEvent(new Event('change', { bubbles: true }));
+            }
+
+            if (scheduleCaption && captionInput) {
+                scheduleCaption.value = captionInput.value;
+            }
+
+            if (uploadStatus) {
+                uploadStatus.style.color = '#16a34a';
+                uploadStatus.textContent = 'URL aplicada a partir da aba de mídia.';
+            }
+
+            previewMedia();
+            showCampaignTab('schedule');
+        }
+
+        async function copyCampaignMediaUrl() {
+            const url = (document.getElementById('campaignMediaUrl')?.value || '').trim();
+            if (!url) {
+                alert('❌ Nenhuma URL disponível para copiar.');
+                return;
+            }
+
+            try {
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    await navigator.clipboard.writeText(url);
+                } else {
+                    const tempInput = document.createElement('input');
+                    tempInput.value = url;
+                    document.body.appendChild(tempInput);
+                    tempInput.select();
+                    document.execCommand('copy');
+                    document.body.removeChild(tempInput);
+                }
+                alert('✅ URL copiada para a área de transferência!');
+            } catch (error) {
+                console.error('Erro ao copiar URL:', error);
+                alert('❌ Não foi possível copiar a URL automaticamente. Copie manualmente.');
+            }
+        }
+
+        function clearCampaignMediaSelection() {
+            resetCampaignMediaManager();
+        }
+
         // Load campaign instances for group selection
         async function loadCampaignInstancesForGroups() {
             const select = document.getElementById('campaignGroupsInstance');


### PR DESCRIPTION
## Summary
- attempt automatic installation of the `minio` dependency with a user-level fallback and clearer guidance for PEP 668 environments
- ensure MinIO uploads set content type, try to apply a public-read policy, and generate presigned URLs when no public endpoint is configured
- add a media management tab to campaign settings so uploaded URLs can be previewed, copied, and applied to scheduled group messages (including document support)

## Testing
- python -m compileall whatsflow-real.py

------
https://chatgpt.com/codex/tasks/task_e_68c8c4de66f4832f94e6647db789a3db