### PR TITLE
Allow additional scheduled message types and add migration

### DIFF
--- a/migrations/update_scheduled_message_types.py
+++ b/migrations/update_scheduled_message_types.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Migration script to allow additional scheduled message types."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+import sys
+from datetime import datetime
+from typing import Optional
+
+LEGACY_COMMENT_MARKER = "-- text, image, audio, video"
+DEFAULT_DB_PATH = os.environ.get("WHATSFLOW_DB_PATH", "whatsflow.db")
+
+
+def _create_backup(db_path: str) -> Optional[str]:
+    """Create a timestamped backup of the database file."""
+
+    if not os.path.exists(db_path):
+        print(f"⚠️ Banco de dados '{db_path}' não encontrado. Nenhum backup criado.")
+        return None
+
+    base_dir = os.path.dirname(db_path) or "."
+    base_name = os.path.splitext(os.path.basename(db_path))[0]
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup_name = f"{base_name}-backup-scheduled-messages-{timestamp}.db"
+    backup_path = os.path.join(base_dir, backup_name)
+
+    shutil.copy2(db_path, backup_path)
+    print(f"📦 Backup criado em: {backup_path}")
+    return backup_path
+
+
+def _fetch_table_sql(cursor: sqlite3.Cursor, table: str) -> Optional[str]:
+    cursor.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    )
+    row = cursor.fetchone()
+    return row[0] if row and row[0] else None
+
+
+def _normalize_existing_rows(cursor: sqlite3.Cursor) -> None:
+    """Normalize stored values to avoid blank or uppercase message types."""
+
+    cursor.execute(
+        """
+        UPDATE scheduled_messages
+        SET message_type = LOWER(TRIM(message_type))
+        WHERE message_type IS NOT NULL
+        """
+    )
+    cursor.execute(
+        """
+        UPDATE scheduled_messages
+        SET message_type = 'text'
+        WHERE message_type IS NULL OR TRIM(message_type) = ''
+        """
+    )
+    cursor.execute(
+        """
+        UPDATE scheduled_messages
+        SET media_url = NULL
+        WHERE media_url IS NOT NULL AND TRIM(media_url) = ''
+        """
+    )
+
+
+def migrate(db_path: str = DEFAULT_DB_PATH) -> bool:
+    """Run migration to allow additional scheduled message types."""
+
+    backup_created = _create_backup(db_path)
+    if backup_created is None and not os.path.exists(db_path):
+        # Database missing and no backup created, nothing to do.
+        return True
+
+    try:
+        conn = sqlite3.connect(db_path)
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+
+        schema_sql = _fetch_table_sql(cursor, "scheduled_messages")
+        if not schema_sql:
+            print("ℹ️ Tabela 'scheduled_messages' não encontrada. Nenhuma alteração necessária.")
+            return True
+
+        needs_rebuild = LEGACY_COMMENT_MARKER in schema_sql or "CHECK" in schema_sql
+
+        if needs_rebuild:
+            print("🔄 Atualizando estrutura da tabela 'scheduled_messages'...")
+            cursor.execute("PRAGMA foreign_keys=OFF")
+            cursor.execute("ALTER TABLE scheduled_messages RENAME TO scheduled_messages_old")
+            cursor.execute(
+                """
+                CREATE TABLE scheduled_messages (
+                    id TEXT PRIMARY KEY,
+                    campaign_id TEXT NOT NULL,
+                    message_text TEXT,
+                    message_type TEXT DEFAULT 'text', -- tipo da mensagem (texto, mídia ou outros formatos compatíveis)
+                    media_url TEXT,
+                    schedule_type TEXT NOT NULL,
+                    schedule_time TEXT NOT NULL,
+                    schedule_days TEXT,
+                    schedule_date TEXT,
+                    is_active INTEGER DEFAULT 1,
+                    next_run TEXT,
+                    created_at TEXT
+                )
+                """
+            )
+            cursor.execute(
+                """
+                INSERT INTO scheduled_messages (
+                    id, campaign_id, message_text, message_type, media_url,
+                    schedule_type, schedule_time, schedule_days, schedule_date,
+                    is_active, next_run, created_at
+                )
+                SELECT
+                    id,
+                    campaign_id,
+                    message_text,
+                    LOWER(COALESCE(NULLIF(TRIM(message_type), ''), 'text')),
+                    CASE
+                        WHEN media_url IS NULL OR TRIM(media_url) = '' THEN NULL
+                        ELSE TRIM(media_url)
+                    END,
+                    schedule_type,
+                    schedule_time,
+                    schedule_days,
+                    schedule_date,
+                    is_active,
+                    next_run,
+                    created_at
+                FROM scheduled_messages_old
+                """
+            )
+            cursor.execute("DROP TABLE scheduled_messages_old")
+            cursor.execute("PRAGMA foreign_keys=ON")
+        else:
+            print("ℹ️ Estrutura da tabela 'scheduled_messages' já está atualizada. Normalizando dados...")
+
+        _normalize_existing_rows(cursor)
+        conn.commit()
+        print("✅ Migração concluída com sucesso!")
+        return True
+    except sqlite3.Error as exc:
+        if 'conn' in locals():
+            conn.rollback()
+        print(f"❌ Erro durante migração: {exc}")
+        return False
+    finally:
+        if 'conn' in locals():
+            conn.close()
+
+
+if __name__ == "__main__":
+    database_path = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_DB_PATH
+    success = migrate(database_path)
+    sys.exit(0 if success else 1)

--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -84,6 +84,59 @@ _MINIO_SECURE_DEFAULT = False
 Minio = None
 
 
+DEFAULT_SCHEDULED_MESSAGE_TYPES: Set[str] = {
+    "text",
+    "image",
+    "audio",
+    "video",
+    "document",
+    "sticker",
+    "location",
+    "contact",
+    "poll",
+}
+
+SCHEDULED_MESSAGE_MEDIA_REQUIRED_TYPES: Set[str] = {
+    "image",
+    "audio",
+    "video",
+    "document",
+    "sticker",
+}
+
+
+def _load_allowed_scheduled_message_types() -> Set[str]:
+    """Return the allowed message types for scheduled messages."""
+
+    env_key = "WHATSFLOW_SCHEDULED_MESSAGE_TYPES"
+    allowed = set(DEFAULT_SCHEDULED_MESSAGE_TYPES)
+    extra = os.environ.get(env_key)
+    if extra:
+        for raw_value in extra.split(","):
+            normalized = raw_value.strip().lower()
+            if normalized:
+                allowed.add(normalized)
+    return allowed
+
+
+SCHEDULED_MESSAGE_ALLOWED_TYPES: Set[str] = _load_allowed_scheduled_message_types()
+
+
+def _format_allowed_message_types() -> str:
+    """Format the allowed message types for human readable messages."""
+
+    return ", ".join(sorted(SCHEDULED_MESSAGE_ALLOWED_TYPES))
+
+
+def normalize_scheduled_message_type(value: Optional[str]) -> str:
+    """Normalize user provided message type values."""
+
+    if value is None:
+        return "text"
+    normalized = str(value).strip().lower()
+    return normalized or "text"
+
+
 def ensure_minio_credentials_table() -> None:
     """Ensure the table used to persist MinIO credentials exists."""
 
@@ -7741,7 +7794,7 @@ def init_db():
             id TEXT PRIMARY KEY,
             campaign_id TEXT NOT NULL,
             message_text TEXT,
-            message_type TEXT DEFAULT 'text', -- text, image, audio, video
+            message_type TEXT DEFAULT 'text', -- tipo da mensagem (texto, mídia ou outros formatos compatíveis)
             media_url TEXT, -- URL for media files
             schedule_type TEXT NOT NULL, -- once, weekly
             schedule_time TEXT NOT NULL, -- HH:MM format
@@ -8661,9 +8714,25 @@ class MessageScheduler:
             for row in messages_to_send:
                 try:
                     message_id = row[0]
-                    message_text = row[2]
-                    message_type = row[3]
-                    media_url = row[4]
+                    message_text = (row[2] or "")
+                    original_message_type = row[3]
+                    message_type = normalize_scheduled_message_type(original_message_type)
+
+                    if message_type not in SCHEDULED_MESSAGE_ALLOWED_TYPES:
+                        logger.warning(
+                            "Tipo de mensagem não suportado '%s' para agendamento %s. Mensagem ignorada.",
+                            original_message_type,
+                            message_id,
+                        )
+                        continue
+
+                    raw_media_url = row[4]
+                    if isinstance(raw_media_url, str):
+                        media_url = raw_media_url.strip() or None
+                    elif raw_media_url is None:
+                        media_url = None
+                    else:
+                        media_url = str(raw_media_url).strip() or None
                     schedule_type = row[5]
                     schedule_time = row[6]
                     schedule_days = row[7]
@@ -8764,6 +8833,26 @@ class MessageScheduler:
                 print(f"❌ {error_msg}")
                 return False, error_msg
 
+            message_type = normalize_scheduled_message_type(message_type)
+            if message_type not in SCHEDULED_MESSAGE_ALLOWED_TYPES:
+                error_msg = f"Tipo de mensagem não suportado: {message_type}"
+                logger.warning(error_msg)
+                return False, error_msg
+
+            if isinstance(media_url, str):
+                clean_media_url = media_url.strip() or None
+            elif media_url is None:
+                clean_media_url = None
+            else:
+                clean_media_url = str(media_url).strip() or None
+
+            if message_type in SCHEDULED_MESSAGE_MEDIA_REQUIRED_TYPES and not clean_media_url:
+                error_msg = (
+                    f"URL de mídia obrigatória para mensagens do tipo '{message_type}'"
+                )
+                logger.warning(error_msg)
+                return False, error_msg
+
             if message_type == 'text':
                 payload = {
                     'to': group_id,
@@ -8774,14 +8863,15 @@ class MessageScheduler:
                 payload = {
                     'to': group_id,
                     'type': message_type,
-                    'mediaUrl': media_url,
                 }
+                if clean_media_url:
+                    payload['mediaUrl'] = clean_media_url
                 if message_text:
                     payload['message'] = message_text
 
             for attempt in range(3):
                 try:
-                    log_details = f"message_type={message_type}, media_url={media_url}"
+                    log_details = f"message_type={message_type}, media_url={clean_media_url}"
                     if message_type == 'text':
                         logger.info(
                             f"📤 Enviando mensagem de texto ao grupo {group_id} ({log_details})"
@@ -10741,12 +10831,21 @@ class WhatsFlowRealHandler(BaseHTTPRequestHandler):
                 created_at = row[11]
                 groups_count = row[12]
 
+                message_type = normalize_scheduled_message_type(row[3])
+                raw_media_url = row[4]
+                if isinstance(raw_media_url, str):
+                    media_url = raw_media_url.strip() or None
+                elif raw_media_url is None:
+                    media_url = None
+                else:
+                    media_url = str(raw_media_url).strip() or None
+
                 messages.append({
                     'id': row[0],
                     'campaign_id': row[1],
                     'message_text': row[2],
-                    'message_type': row[3],
-                    'media_url': row[4],
+                    'message_type': message_type,
+                    'media_url': media_url,
                     'schedule_type': row[5],
                     'schedule_time': row[6],
                     'schedule_days': row[7],
@@ -10790,12 +10889,21 @@ class WhatsFlowRealHandler(BaseHTTPRequestHandler):
                 group_name = row[13]
                 instance_id = row[14]
 
+                message_type = normalize_scheduled_message_type(row[3])
+                raw_media_url = row[4]
+                if isinstance(raw_media_url, str):
+                    media_url = raw_media_url.strip() or None
+                elif raw_media_url is None:
+                    media_url = None
+                else:
+                    media_url = str(raw_media_url).strip() or None
+
                 messages.append({
                     'id': row[0],
                     'campaign_id': row[1],
                     'message_text': row[2],
-                    'message_type': row[3],
-                    'media_url': row[4],
+                    'message_type': message_type,
+                    'media_url': media_url,
                     'schedule_type': row[5],
                     'schedule_time': row[6],
                     'schedule_days': row[7],
@@ -10834,11 +10942,72 @@ class WhatsFlowRealHandler(BaseHTTPRequestHandler):
             campaign_id = data.get('campaign_id', None)
             
             # Optional fields
-            message_text = data.get('message_text', '')
-            message_type = data.get('message_type', 'text')
-            media_url = data.get('media_url', '')
+            raw_message_text = data.get('message_text', '')
+            message_text = (
+                raw_message_text
+                if isinstance(raw_message_text, str)
+                else str(raw_message_text)
+            )
+
+            message_type = normalize_scheduled_message_type(
+                data.get('message_type', 'text')
+            )
+            if message_type not in SCHEDULED_MESSAGE_ALLOWED_TYPES:
+                allowed_values = _format_allowed_message_types()
+                self.send_json_response(
+                    {
+                        "error": (
+                            "Tipo de mensagem inválido. Valores permitidos: "
+                            f"{allowed_values}"
+                        )
+                    },
+                    400,
+                )
+                return
+
+            raw_media_url = data.get('media_url')
+            if isinstance(raw_media_url, str):
+                media_url = raw_media_url.strip()
+            elif raw_media_url is None:
+                media_url = ''
+            else:
+                media_url = str(raw_media_url).strip()
+
+            clean_media_url = media_url or None
+            if (
+                message_type in SCHEDULED_MESSAGE_MEDIA_REQUIRED_TYPES
+                and not clean_media_url
+            ):
+                self.send_json_response(
+                    {
+                        "error": (
+                            "URL de mídia é obrigatória para mensagens do tipo "
+                            f"'{message_type}'"
+                        )
+                    },
+                    400,
+                )
+                return
+
             schedule_date = data.get('schedule_date')
-            schedule_days = data.get('schedule_days', [])
+
+            schedule_days_raw = data.get('schedule_days', [])
+            if isinstance(schedule_days_raw, str):
+                try:
+                    parsed_days = json.loads(schedule_days_raw)
+                    schedule_days = parsed_days if isinstance(parsed_days, list) else []
+                except json.JSONDecodeError:
+                    schedule_days = []
+            elif isinstance(schedule_days_raw, list):
+                schedule_days = schedule_days_raw
+            else:
+                schedule_days = []
+
+            schedule_days = [
+                str(day).strip().lower()
+                for day in schedule_days
+                if isinstance(day, str) and day.strip()
+            ]
             
             if not all([group_id, group_name, instance_id, schedule_type, schedule_time]):
                 self.send_json_response({"error": "Campos obrigatórios faltando"}, 400)
@@ -10914,17 +11083,29 @@ class WhatsFlowRealHandler(BaseHTTPRequestHandler):
             message_id = str(uuid.uuid4())
             created_at = datetime.now().isoformat()
             
-            cursor.execute("""
-                INSERT INTO scheduled_messages 
-                (id, campaign_id, message_text, message_type, media_url, 
-                 schedule_type, schedule_time, schedule_days, schedule_date, 
+            cursor.execute(
+                """
+                INSERT INTO scheduled_messages
+                (id, campaign_id, message_text, message_type, media_url,
+                 schedule_type, schedule_time, schedule_days, schedule_date,
                  is_active, next_run, created_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """, (
-                message_id, campaign_id, message_text, message_type, media_url,
-                schedule_type, schedule_time, json.dumps(schedule_days), schedule_date,
-                1, next_run, created_at
-            ))
+                """,
+                (
+                    message_id,
+                    campaign_id,
+                    message_text,
+                    message_type,
+                    clean_media_url,
+                    schedule_type,
+                    schedule_time,
+                    json.dumps(schedule_days),
+                    schedule_date,
+                    1,
+                    next_run,
+                    created_at,
+                ),
+            )
             
             # Store group and instance info in separate table for easier querying
             cursor.execute("""


### PR DESCRIPTION
## Summary
- centralize the list of supported scheduled message types and expose helpers to normalize inputs
- harden the scheduler and REST handlers so new message types are validated, sanitized and logged consistently
- ship a migration that rebuilds scheduled_messages when needed and normalizes stored message_type/media_url values

## Testing
- python -m compileall whatsflow-real.py migrations/update_scheduled_message_types.py

------
https://chatgpt.com/codex/tasks/task_e_68c8db75e500832fbaeb5bf22abcdb6a