### PR TITLE
Add group management endpoints and UI

### DIFF
--- a/baileys_service/server.js
+++ b/baileys_service/server.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const cors = require('cors');
-const { DisconnectReason, useMultiFileAuthState, downloadMediaMessage } = require('@whiskeysockets/baileys');
+const { DisconnectReason, useMultiFileAuthState, downloadMediaMessage, jidNormalizedUser } = require('@whiskeysockets/baileys');
 const makeWASocket = require('@whiskeysockets/baileys').default;
 const qrTerminal = require('qrcode-terminal');
 const fs = require('fs');
@@ -19,6 +19,227 @@ app.use(express.json());
 let instances = new Map(); // instanceId -> { sock, qr, connected, connecting, user }
 let currentQR = null;
 let qrUpdateInterval = null;
+
+const PARTICIPANT_ACTIONS = new Set(['add', 'remove', 'promote', 'demote']);
+
+const normalizeJid = (jid) => {
+    if (!jid || typeof jid !== 'string') {
+        return jid;
+    }
+
+    try {
+        return jidNormalizedUser(jid);
+    } catch (err) {
+        return jid;
+    }
+};
+
+const ensureGroupJid = (groupId) => {
+    if (!groupId || typeof groupId !== 'string') {
+        throw new Error('ID do grupo inválido');
+    }
+
+    const trimmed = groupId.trim();
+    if (!trimmed) {
+        throw new Error('ID do grupo inválido');
+    }
+
+    return trimmed.endsWith('@g.us') ? trimmed : `${trimmed}@g.us`;
+};
+
+const ensureParticipantJid = (participant) => {
+    if (!participant || typeof participant !== 'string') {
+        throw new Error('Participante inválido');
+    }
+
+    const trimmed = participant.trim();
+    if (!trimmed) {
+        throw new Error('Participante inválido');
+    }
+
+    if (trimmed.includes('@')) {
+        return trimmed;
+    }
+
+    return `${trimmed}@s.whatsapp.net`;
+};
+
+const getInstanceOrThrow = (instanceId) => {
+    const instance = instances.get(instanceId);
+    if (!instance || !instance.connected || !instance.sock) {
+        const error = new Error(`Instância ${instanceId} não está conectada`);
+        error.statusCode = 400;
+        throw error;
+    }
+
+    return instance;
+};
+
+const ensureGroupCache = (instance) => {
+    if (!instance.groupMetadata) {
+        instance.groupMetadata = new Map();
+    }
+    return instance.groupMetadata;
+};
+
+const getMeJid = (instance) => {
+    const userId = instance?.sock?.user?.id;
+    if (!userId) {
+        return null;
+    }
+
+    return normalizeJid(userId);
+};
+
+const buildParticipantsSummary = (participants = [], meJid = null) => {
+    return participants.map((participant) => {
+        const id = participant?.id || participant?.jid || participant?.user || participant?.participant || participant;
+        const participantJid = typeof id === 'string' ? id : '';
+        const normalized = participantJid ? normalizeJid(participantJid) : participantJid;
+        const adminValue = participant?.admin;
+        const isAdmin = Boolean(adminValue && adminValue !== 'none');
+        const isSuperAdmin = adminValue === 'superadmin';
+        const isMe = meJid ? normalizeJid(participantJid) === meJid : false;
+
+        return {
+            id: participantJid || normalized,
+            jid: participantJid || normalized,
+            name: participant?.name || participant?.notify || participant?.displayName || '',
+            isAdmin,
+            isSuperAdmin,
+            isMe,
+            phone: normalized?.endsWith('@s.whatsapp.net') ? normalized.replace('@s.whatsapp.net', '') : undefined,
+            status: participant?.status
+        };
+    });
+};
+
+const serializeGroupMetadata = (metadata, instance) => {
+    if (!metadata) {
+        return null;
+    }
+
+    const meJid = getMeJid(instance);
+    const participants = buildParticipantsSummary(metadata.participants || [], meJid);
+    const isAdmin = participants.some((participant) => participant.isMe && participant.isAdmin);
+
+    const announcementFlag = metadata?.announce;
+    const restrictFlag = metadata?.restrict;
+
+    return {
+        id: metadata.id || metadata.jid || metadata.gid,
+        jid: metadata.id || metadata.jid || metadata.gid,
+        name: metadata.subject || metadata.name || 'Grupo sem nome',
+        description: metadata.desc || metadata.description || '',
+        owner: metadata.owner || metadata.creator || metadata.superAdmin,
+        participants,
+        participantCount: participants.length,
+        permissions: {
+            isAdmin,
+            canManageParticipants: isAdmin,
+            canEditInfo: isAdmin
+        },
+        settings: {
+            announcement: announcementFlag === true || announcementFlag === 'true',
+            locked: restrictFlag === true || restrictFlag === 'true',
+            ephemeralDuration: metadata.ephemeralDuration || null
+        },
+        creation: metadata.creation || null,
+        createdAt: metadata.creation ? new Date(metadata.creation * 1000).toISOString() : null,
+        lastSyncedAt: metadata.lastSynced ? new Date(metadata.lastSynced).toISOString() : null
+    };
+};
+
+const refreshGroupCache = async (instanceId) => {
+    const instance = getInstanceOrThrow(instanceId);
+    const cache = ensureGroupCache(instance);
+
+    const groups = await instance.sock.groupFetchAllParticipating();
+    cache.clear();
+
+    const timestamp = Date.now();
+    for (const [groupJid, metadata] of Object.entries(groups)) {
+        metadata.id = groupJid;
+        metadata.lastSynced = timestamp;
+        cache.set(groupJid, metadata);
+    }
+
+    instance.groupCacheInitialized = true;
+    instance.groupCacheTimestamp = timestamp;
+
+    return cache;
+};
+
+const getGroupMetadataFromCache = async (instanceId, groupId, { forceRefresh = false } = {}) => {
+    const instance = getInstanceOrThrow(instanceId);
+    const cache = ensureGroupCache(instance);
+    const groupJid = ensureGroupJid(groupId);
+
+    let metadata = cache.get(groupJid);
+    if (!metadata || forceRefresh) {
+        metadata = await instance.sock.groupMetadata(groupJid);
+        metadata.id = groupJid;
+        metadata.lastSynced = Date.now();
+        cache.set(groupJid, metadata);
+    }
+
+    return { instance, metadata, groupJid };
+};
+
+const ensureAdminPrivileges = async (instanceId, groupId) => {
+    const { instance, metadata, groupJid } = await getGroupMetadataFromCache(instanceId, groupId);
+    const meJid = getMeJid(instance);
+    const participants = metadata?.participants || [];
+
+    const isAdmin = participants.some((participant) => {
+        const participantId = participant?.id || participant?.jid;
+        if (!participantId) {
+            return false;
+        }
+        return normalizeJid(participantId) === meJid && participant?.admin;
+    });
+
+    if (!isAdmin) {
+        const error = new Error('Usuário conectado não é administrador do grupo');
+        error.statusCode = 403;
+        throw error;
+    }
+
+    return { instance, metadata, groupJid };
+};
+
+const applyParticipantsChange = (metadata, participants, action) => {
+    if (!metadata.participants) {
+        metadata.participants = [];
+    }
+
+    const normalizedMap = new Map();
+    for (const participant of metadata.participants) {
+        const participantId = participant?.id || participant?.jid;
+        if (!participantId) {
+            continue;
+        }
+        normalizedMap.set(normalizeJid(participantId), { ...participant });
+    }
+
+    for (const participant of participants) {
+        const participantJid = normalizeJid(ensureParticipantJid(participant));
+        const existing = normalizedMap.get(participantJid) || { id: participantJid };
+
+        if (action === 'add') {
+            normalizedMap.set(participantJid, { ...existing, id: existing.id || participantJid });
+        } else if (action === 'remove') {
+            normalizedMap.delete(participantJid);
+        } else if (action === 'promote') {
+            normalizedMap.set(participantJid, { ...existing, id: existing.id || participantJid, admin: existing.admin === 'superadmin' ? 'superadmin' : 'admin' });
+        } else if (action === 'demote') {
+            normalizedMap.set(participantJid, { ...existing, id: existing.id || participantJid, admin: null });
+        }
+    }
+
+    metadata.participants = Array.from(normalizedMap.values());
+    metadata.lastSynced = Date.now();
+};
 
 // QR Code auto-refresh every 30 seconds (WhatsApp QR expires after 60s)
 const startQRRefresh = (instanceId) => {
@@ -72,7 +293,10 @@ async function connectInstance(instanceId) {
             connected: false,
             connecting: true,
             user: null,
-            lastSeen: new Date()
+            lastSeen: new Date(),
+            groupMetadata: new Map(),
+            groupCacheInitialized: false,
+            groupCacheTimestamp: null
         });
 
         sock.ev.on('connection.update', async (update) => {
@@ -103,6 +327,11 @@ async function connectInstance(instanceId) {
                 instance.connected = false;
                 instance.connecting = false;
                 instance.user = null;
+                if (instance.groupMetadata) {
+                    instance.groupMetadata.clear();
+                }
+                instance.groupCacheInitialized = false;
+                instance.groupCacheTimestamp = null;
                 stopQRRefresh();
                 
                 // Implement robust reconnection logic
@@ -168,9 +397,9 @@ async function connectInstance(instanceId) {
                     profilePictureUrl: null,
                     phone: sock.user.id.split(':')[0]
                 };
-                
+
                 console.log(`👤 Usuário conectado: ${instance.user.name} (${instance.user.phone})`);
-                
+
                 // Try to get profile picture
                 try {
                     const profilePic = await sock.profilePictureUrl(sock.user.id, 'image');
@@ -179,7 +408,14 @@ async function connectInstance(instanceId) {
                 } catch (err) {
                     console.log('⚠️ Não foi possível obter foto do perfil');
                 }
-                
+
+                try {
+                    await refreshGroupCache(instanceId);
+                    console.log('📚 Cache de grupos inicializado');
+                } catch (err) {
+                    console.log('⚠️ Não foi possível inicializar cache de grupos:', err.message);
+                }
+
                 // Wait a bit before importing chats to ensure connection is stable
                 setTimeout(async () => {
                     try {
@@ -252,7 +488,7 @@ async function connectInstance(instanceId) {
         // Handle incoming messages with better error handling
         sock.ev.on('messages.upsert', async (m) => {
             const messages = m.messages;
-            
+
             for (const message of messages) {
                 if (!message.key.fromMe && message.message) {
                     const from = message.key.remoteJid;
@@ -302,6 +538,77 @@ async function connectInstance(instanceId) {
                             }
                         }
                     }
+                }
+            }
+        });
+
+        sock.ev.on('groups.update', (updates) => {
+            const instance = instances.get(instanceId);
+            if (!instance) {
+                return;
+            }
+
+            const cache = ensureGroupCache(instance);
+            const list = Array.isArray(updates) ? updates : [updates];
+            const timestamp = Date.now();
+
+            for (const update of list) {
+                if (!update || !update.id) {
+                    continue;
+                }
+
+                try {
+                    const groupJid = ensureGroupJid(update.id);
+                    const existing = cache.get(groupJid) || { id: groupJid };
+                    const merged = { ...existing, ...update };
+
+                    if (update.subject !== undefined) {
+                        merged.subject = update.subject;
+                    }
+
+                    if (update.desc !== undefined) {
+                        merged.desc = update.desc;
+                    }
+
+                    merged.lastSynced = timestamp;
+                    cache.set(groupJid, merged);
+                } catch (err) {
+                    console.log('⚠️ Erro ao atualizar metadata do grupo:', err.message);
+                }
+            }
+        });
+
+        sock.ev.on('group-participants.update', async (updates) => {
+            const instance = instances.get(instanceId);
+            if (!instance) {
+                return;
+            }
+
+            const cache = ensureGroupCache(instance);
+            const list = Array.isArray(updates) ? updates : [updates];
+
+            for (const update of list) {
+                if (!update || !update.id || !update.participants || !update.action) {
+                    continue;
+                }
+
+                try {
+                    const groupJid = ensureGroupJid(update.id);
+                    let metadata = cache.get(groupJid);
+
+                    if (!metadata) {
+                        try {
+                            metadata = await instance.sock.groupMetadata(groupJid);
+                            metadata.id = groupJid;
+                        } catch (err) {
+                            metadata = { id: groupJid, participants: [] };
+                        }
+                    }
+
+                    applyParticipantsChange(metadata, update.participants, update.action);
+                    cache.set(groupJid, metadata);
+                } catch (err) {
+                    console.log('⚠️ Erro ao atualizar participantes do grupo:', err.message);
                 }
             }
         });
@@ -464,86 +771,348 @@ app.post('/send/:instanceId', async (req, res) => {
 // Groups endpoint with robust error handling  
 app.get('/groups/:instanceId', async (req, res) => {
     const { instanceId } = req.params;
-    
+    const { refresh } = req.query;
+
     try {
-        const instance = instances.get(instanceId);
-        if (!instance || !instance.connected || !instance.sock) {
-            return res.status(400).json({ 
-                success: false,
-                error: `Instância ${instanceId} não está conectada`,
-                instanceId: instanceId,
-                groups: []
-            });
-        }
-        
-        console.log(`📥 Buscando grupos para instância: ${instanceId}`);
-        
-        // Multiple methods to get groups
-        let groups = [];
-        
-        try {
-            // Method 1: Get group metadata
-            const groupIds = await instance.sock.groupFetchAllParticipating();
-            console.log(`📊 Encontrados ${Object.keys(groupIds).length} grupos via groupFetchAllParticipating`);
-            
-            for (const [groupId, groupData] of Object.entries(groupIds)) {
-                groups.push({
-                    id: groupId,
-                    name: groupData.subject || 'Grupo sem nome',
-                    description: groupData.desc || '',
-                    participants: groupData.participants ? groupData.participants.length : 0,
-                    admin: groupData.participants ? 
-                           groupData.participants.some(p => p.admin && p.id === instance.user?.id) : false,
-                    created: groupData.creation || null
-                });
-            }
-        } catch (error) {
-            console.log(`⚠️ Método 1 falhou: ${error.message}`);
-            
+        const instance = getInstanceOrThrow(instanceId);
+
+        if (refresh === 'true') {
             try {
-                // Method 2: Get chats and filter groups
-                const chats = await instance.sock.getChats();
-                const groupChats = chats.filter(chat => chat.id.endsWith('@g.us'));
-                console.log(`📊 Encontrados ${groupChats.length} grupos via getChats`);
-                
-                groups = groupChats.map(chat => ({
-                    id: chat.id,
-                    name: chat.name || chat.subject || 'Grupo sem nome',
-                    description: chat.description || '',
-                    participants: chat.participantsCount || 0,
-                    admin: false, // Cannot determine admin status from chat
-                    created: chat.timestamp || null,
-                    lastMessage: chat.lastMessage ? {
-                        text: chat.lastMessage.message || '',
-                        timestamp: chat.lastMessage.timestamp
-                    } : null
-                }));
-            } catch (error2) {
-                console.log(`⚠️ Método 2 falhou: ${error2.message}`);
-                
-                // Method 3: Simple fallback - return empty with proper structure
-                groups = [];
+                await refreshGroupCache(instanceId);
+            } catch (err) {
+                console.log('⚠️ Erro ao atualizar cache de grupos:', err.message);
+            }
+        } else if (!instance.groupCacheInitialized) {
+            try {
+                await refreshGroupCache(instanceId);
+            } catch (err) {
+                console.log('⚠️ Cache de grupos não pôde ser inicializado automaticamente:', err.message);
             }
         }
-        
-        console.log(`✅ Retornando ${groups.length} grupos para instância ${instanceId}`);
-        
+
+        const cache = ensureGroupCache(instance);
+        let metadataList = Array.from(cache.values());
+        let source = 'cache';
+
+        if (metadataList.length === 0) {
+            source = 'fallback';
+            try {
+                const chats = await instance.sock.getChats();
+                metadataList = chats
+                    .filter((chat) => chat.id && chat.id.endsWith('@g.us'))
+                    .map((chat) => ({
+                        id: chat.id,
+                        subject: chat.name || chat.subject || 'Grupo sem nome',
+                        desc: chat.description || '',
+                        participants: [],
+                        creation: chat.timestamp,
+                        lastSynced: Date.now()
+                    }));
+            } catch (fallbackError) {
+                console.log('⚠️ Falha no fallback de grupos:', fallbackError.message);
+                metadataList = [];
+            }
+        }
+
+        const groups = metadataList
+            .map((metadata) => serializeGroupMetadata(metadata, instance))
+            .filter(Boolean);
+
         res.json({
             success: true,
-            instanceId: instanceId,
-            groups: groups,
+            instanceId,
+            groups,
             count: groups.length,
+            cache: {
+                initialized: instance.groupCacheInitialized || false,
+                lastSyncedAt: instance.groupCacheTimestamp ? new Date(instance.groupCacheTimestamp).toISOString() : null,
+                source
+            },
             timestamp: new Date().toISOString()
         });
-        
     } catch (error) {
-        console.error(`❌ Erro ao buscar grupos para instância ${instanceId}:`, error);
-        res.status(500).json({
+        const status = error.statusCode || 500;
+        console.error(`❌ Erro ao buscar grupos para instância ${instanceId}:`, error.message);
+        res.status(status).json({
             success: false,
-            error: `Erro interno ao buscar grupos: ${error.message}`,
-            instanceId: instanceId,
+            error: error.message,
+            instanceId,
             groups: []
         });
+    }
+});
+
+app.post('/groups/:instanceId', async (req, res) => {
+    const { instanceId } = req.params;
+    const { subject, participants = [] } = req.body || {};
+
+    if (!subject || typeof subject !== 'string') {
+        return res.status(400).json({ success: false, error: 'Assunto do grupo é obrigatório' });
+    }
+
+    const participantList = Array.isArray(participants) ? participants : [participants];
+    let normalizedParticipants;
+
+    try {
+        normalizedParticipants = Array.from(new Set(participantList.map(ensureParticipantJid)));
+    } catch (err) {
+        return res.status(400).json({ success: false, error: err.message });
+    }
+
+    try {
+        const instance = getInstanceOrThrow(instanceId);
+        const metadata = await instance.sock.groupCreate(subject, normalizedParticipants);
+        const groupJid = ensureGroupJid(metadata.id || metadata.gid);
+
+        metadata.id = groupJid;
+        metadata.lastSynced = Date.now();
+
+        const cache = ensureGroupCache(instance);
+        cache.set(groupJid, metadata);
+        instance.groupCacheInitialized = true;
+        instance.groupCacheTimestamp = metadata.lastSynced;
+
+        res.json({
+            success: true,
+            instanceId,
+            groupId: groupJid,
+            group: serializeGroupMetadata(metadata, instance),
+            participantsAdded: normalizedParticipants.length
+        });
+    } catch (error) {
+        const status = error.statusCode || 500;
+        res.status(status).json({ success: false, error: error.message });
+    }
+});
+
+app.post('/groups/:instanceId/:groupId/participants', async (req, res) => {
+    const { instanceId, groupId } = req.params;
+    const { action, participants } = req.body || {};
+
+    const normalizedAction = typeof action === 'string' ? action.toLowerCase() : null;
+    if (!normalizedAction || !PARTICIPANT_ACTIONS.has(normalizedAction)) {
+        return res.status(400).json({ success: false, error: 'Ação inválida. Use add, remove, promote ou demote.' });
+    }
+
+    const participantList = Array.isArray(participants) ? participants : [participants];
+    if (!participantList.length) {
+        return res.status(400).json({ success: false, error: 'Informe ao menos um participante' });
+    }
+
+    let normalizedParticipants;
+
+    try {
+        normalizedParticipants = Array.from(new Set(participantList.map(ensureParticipantJid)));
+    } catch (err) {
+        return res.status(400).json({ success: false, error: err.message });
+    }
+
+    try {
+        const { instance, metadata, groupJid } = await ensureAdminPrivileges(instanceId, groupId);
+        const result = await instance.sock.groupParticipantsUpdate(groupJid, normalizedParticipants, normalizedAction);
+
+        applyParticipantsChange(metadata, normalizedParticipants, normalizedAction);
+        ensureGroupCache(instance).set(groupJid, metadata);
+        metadata.lastSynced = Date.now();
+
+        res.json({
+            success: true,
+            instanceId,
+            groupId: groupJid,
+            action: normalizedAction,
+            result: (result || []).map((item, index) => ({
+                jid: item?.jid || normalizedParticipants[index],
+                status: item?.status
+            })),
+            group: serializeGroupMetadata(metadata, instance)
+        });
+    } catch (error) {
+        const status = error.statusCode || 500;
+        res.status(status).json({ success: false, error: error.message });
+    }
+});
+
+app.patch('/groups/:instanceId/:groupId/subject', async (req, res) => {
+    const { instanceId, groupId } = req.params;
+    const { subject } = req.body || {};
+
+    if (!subject || typeof subject !== 'string') {
+        return res.status(400).json({ success: false, error: 'Novo assunto é obrigatório' });
+    }
+
+    try {
+        const { instance, metadata, groupJid } = await ensureAdminPrivileges(instanceId, groupId);
+        await instance.sock.groupUpdateSubject(groupJid, subject);
+
+        metadata.subject = subject;
+        metadata.lastSynced = Date.now();
+        ensureGroupCache(instance).set(groupJid, metadata);
+
+        res.json({
+            success: true,
+            instanceId,
+            groupId: groupJid,
+            group: serializeGroupMetadata(metadata, instance)
+        });
+    } catch (error) {
+        const status = error.statusCode || 500;
+        res.status(status).json({ success: false, error: error.message });
+    }
+});
+
+app.patch('/groups/:instanceId/:groupId/description', async (req, res) => {
+    const { instanceId, groupId } = req.params;
+    const { description = '' } = req.body || {};
+
+    try {
+        const { instance, metadata, groupJid } = await ensureAdminPrivileges(instanceId, groupId);
+        await instance.sock.groupUpdateDescription(groupJid, description);
+
+        metadata.desc = description;
+        metadata.description = description;
+        metadata.lastSynced = Date.now();
+        ensureGroupCache(instance).set(groupJid, metadata);
+
+        res.json({
+            success: true,
+            instanceId,
+            groupId: groupJid,
+            group: serializeGroupMetadata(metadata, instance)
+        });
+    } catch (error) {
+        const status = error.statusCode || 500;
+        res.status(status).json({ success: false, error: error.message });
+    }
+});
+
+app.patch('/groups/:instanceId/:groupId/settings', async (req, res) => {
+    const { instanceId, groupId } = req.params;
+    const { setting, announcement, locked } = req.body || {};
+
+    const operations = [];
+
+    if (setting) {
+        const normalizedSetting = setting.toLowerCase();
+        if (!['announcement', 'not_announcement', 'locked', 'unlocked'].includes(normalizedSetting)) {
+            return res.status(400).json({ success: false, error: 'Setting inválido' });
+        }
+        operations.push(normalizedSetting);
+    }
+
+    if (typeof announcement === 'boolean') {
+        operations.push(announcement ? 'announcement' : 'not_announcement');
+    }
+
+    if (typeof locked === 'boolean') {
+        operations.push(locked ? 'locked' : 'unlocked');
+    }
+
+    if (!operations.length) {
+        return res.status(400).json({ success: false, error: 'Nenhuma alteração informada' });
+    }
+
+    try {
+        const { instance, metadata, groupJid } = await ensureAdminPrivileges(instanceId, groupId);
+        const applied = [];
+
+        for (const op of operations) {
+            await instance.sock.groupSettingUpdate(groupJid, op);
+            applied.push(op);
+
+            if (op === 'announcement') {
+                metadata.announce = 'true';
+            } else if (op === 'not_announcement') {
+                metadata.announce = 'false';
+            } else if (op === 'locked') {
+                metadata.restrict = 'true';
+            } else if (op === 'unlocked') {
+                metadata.restrict = 'false';
+            }
+        }
+
+        metadata.lastSynced = Date.now();
+        ensureGroupCache(instance).set(groupJid, metadata);
+
+        res.json({
+            success: true,
+            instanceId,
+            groupId: groupJid,
+            applied,
+            group: serializeGroupMetadata(metadata, instance)
+        });
+    } catch (error) {
+        const status = error.statusCode || 500;
+        res.status(status).json({ success: false, error: error.message });
+    }
+});
+
+app.post('/groups/:instanceId/:groupId/leave', async (req, res) => {
+    const { instanceId, groupId } = req.params;
+
+    try {
+        const { instance, metadata, groupJid } = await getGroupMetadataFromCache(instanceId, groupId);
+        await instance.sock.groupLeave(groupJid);
+
+        ensureGroupCache(instance).delete(groupJid);
+        metadata.leftAt = new Date().toISOString();
+
+        res.json({
+            success: true,
+            instanceId,
+            groupId: groupJid,
+            message: 'Instância removida do grupo com sucesso'
+        });
+    } catch (error) {
+        const status = error.statusCode || 500;
+        res.status(status).json({ success: false, error: error.message });
+    }
+});
+
+app.get('/groups/:instanceId/:groupId/invite-code', async (req, res) => {
+    const { instanceId, groupId } = req.params;
+
+    try {
+        const { instance, metadata, groupJid } = await ensureAdminPrivileges(instanceId, groupId);
+        const code = await instance.sock.groupInviteCode(groupJid);
+
+        metadata.inviteCode = code;
+        metadata.lastSynced = Date.now();
+        ensureGroupCache(instance).set(groupJid, metadata);
+
+        res.json({
+            success: true,
+            instanceId,
+            groupId: groupJid,
+            code,
+            group: serializeGroupMetadata(metadata, instance)
+        });
+    } catch (error) {
+        const status = error.statusCode || 500;
+        res.status(status).json({ success: false, error: error.message });
+    }
+});
+
+app.post('/groups/:instanceId/:groupId/revoke-invite', async (req, res) => {
+    const { instanceId, groupId } = req.params;
+
+    try {
+        const { instance, metadata, groupJid } = await ensureAdminPrivileges(instanceId, groupId);
+        const newCode = await instance.sock.groupRevokeInvite(groupJid);
+
+        metadata.inviteCode = newCode;
+        metadata.lastSynced = Date.now();
+        ensureGroupCache(instance).set(groupJid, metadata);
+
+        res.json({
+            success: true,
+            instanceId,
+            groupId: groupJid,
+            code: newCode,
+            group: serializeGroupMetadata(metadata, instance)
+        });
+    } catch (error) {
+        const status = error.statusCode || 500;
+        res.status(status).json({ success: false, error: error.message });
     }
 });
 

--- a/docs/GROUPS_OPERATIONS.md
+++ b/docs/GROUPS_OPERATIONS.md
@@ -1,0 +1,154 @@
+# Gerenciamento de Grupos via Baileys Service
+
+Este documento descreve como utilizar os novos recursos de grupos expostos pelo
+serviço Node (`baileys_service`). Todas as rotas estão protegidas por validações
+de conexão e de permissão para garantir que apenas instâncias conectadas e com
+privilegios de administrador executem ações sensíveis.
+
+## Cache de metadados
+
+- Cada instância mantém um cache em memória com os metadados de grupos
+  (`subject`, `description`, `participants`, configurações etc.).
+- O cache é preenchido automaticamente após a conexão e mantido atualizado pelos
+  eventos `groups.update` e `group-participants.update` do Baileys.
+- Quando necessário, utilize `GET /groups/{instanceId}?refresh=true` para forçar
+  uma sincronização completa diretamente com o WhatsApp.
+
+## Endpoints disponíveis
+
+### Listar grupos
+
+`GET /groups/{instanceId}`
+
+- Retorna a lista de grupos conhecidos para a instância.
+- Query `refresh=true` força recarga a partir da API do WhatsApp.
+- Resposta padrão:
+  ```json
+  {
+    "success": true,
+    "instanceId": "whatsapp_1",
+    "groups": [
+      {
+        "jid": "1234567890-123@g.us",
+        "name": "Meu Grupo",
+        "description": "Descrição atual",
+        "participantCount": 32,
+        "permissions": {
+          "isAdmin": true,
+          "canManageParticipants": true,
+          "canEditInfo": true
+        },
+        "settings": {
+          "announcement": false,
+          "locked": true
+        }
+      }
+    ],
+    "cache": {
+      "initialized": true,
+      "lastSyncedAt": "2025-01-01T12:00:00.000Z",
+      "source": "cache"
+    }
+  }
+  ```
+- Erros comuns: `400 Instância não conectada`.
+
+### Criar grupo
+
+`POST /groups/{instanceId}`
+
+Body:
+```json
+{
+  "subject": "Novo grupo",
+  "participants": ["5511999999999", "558199999999"]
+}
+```
+- `participants` é opcional. Telefones podem ser enviados sem domínio
+  (`@s.whatsapp.net` é completado pelo serviço).
+- Respostas de erro: `400` para assunto ausente ou participante inválido.
+
+### Gerenciar participantes
+
+`POST /groups/{instanceId}/{groupId}/participants`
+
+Body:
+```json
+{
+  "action": "add | remove | promote | demote",
+  "participants": ["5511999999999@s.whatsapp.net"]
+}
+```
+- Requer que a instância seja administradora do grupo (senão retorna `403`).
+- A resposta inclui o status retornado pelo WhatsApp e o metadado atualizado.
+
+### Atualizar assunto
+
+`PATCH /groups/{instanceId}/{groupId}/subject`
+
+Body: `{ "subject": "Novo nome" }`
+
+- Necessita privilégio de administrador.
+- Erros: `400` para assunto vazio, `403` quando o usuário não é admin.
+
+### Atualizar descrição
+
+`PATCH /groups/{instanceId}/{groupId}/description`
+
+Body: `{ "description": "Nova descrição" }`
+
+- Aceita string vazia para limpar a descrição.
+- Requer permissão de administrador.
+
+### Ajustar configurações
+
+`PATCH /groups/{instanceId}/{groupId}/settings`
+
+Body de exemplo:
+```json
+{
+  "announcement": true,
+  "locked": false
+}
+```
+- Campos aceitos:
+  - `announcement` (boolean): ativa/desativa modo "somente administradores".
+  - `locked` (boolean): controla se apenas admins podem alterar dados do grupo.
+  - `setting`: aceita valores diretos do Baileys (`announcement`,
+    `not_announcement`, `locked`, `unlocked`).
+- Retorna a lista de alterações aplicadas.
+- Erros: `400` quando nenhum campo é enviado, `403` quando a instância não é
+  administradora.
+
+### Sair do grupo
+
+`POST /groups/{instanceId}/{groupId}/leave`
+
+- Remove a instância do grupo e limpa o cache local.
+- Não exige privilégios de admin (o usuário pode sair a qualquer momento).
+
+### Código de convite
+
+`GET /groups/{instanceId}/{groupId}/invite-code`
+
+- Retorna o código atual do grupo. Exige permissão de administrador (`403` caso
+  contrário).
+
+### Revogar convite
+
+`POST /groups/{instanceId}/{groupId}/revoke-invite`
+
+- Gera um novo código de convite, invalidando o anterior. Também exige permissão
+  de administrador.
+
+## Tratamento de erros
+
+- `400 Bad Request`: parâmetros inválidos, instância desconectada ou lista de
+  participantes vazia.
+- `403 Forbidden`: a instância conectada não possui privilégios de administrador
+  para executar a operação.
+- `500 Internal Server Error`: erros inesperados devolvidos pelo Baileys ou pela
+  própria API do WhatsApp.
+
+Sempre valide as respostas e trate mensagens de erro exibidas no campo
+`error` para orientar corretamente o usuário final.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2555,3 +2555,460 @@ body {
     flex: 0 0 auto;
   }
 }
+
+/* Groups Manager */
+.groups-manager {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.groups-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: white;
+  padding: 1.5rem 2rem;
+  border-radius: 16px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+}
+
+.groups-header h2 {
+  color: #2d3748;
+  margin-bottom: 0.25rem;
+}
+
+.groups-header p {
+  color: #718096;
+  font-size: 0.95rem;
+}
+
+.groups-header-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.groups-header-actions button {
+  border: none;
+  border-radius: 8px;
+  padding: 0.75rem 1.25rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.refresh-btn {
+  background: #edf2f7;
+  color: #2d3748;
+}
+
+.refresh-btn:hover {
+  background: #e2e8f0;
+}
+
+.create-group-btn {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  box-shadow: 0 6px 20px rgba(118, 75, 162, 0.35);
+}
+
+.create-group-btn:hover {
+  transform: translateY(-2px);
+}
+
+.groups-feedback {
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  font-weight: 500;
+}
+
+.groups-feedback.success {
+  background: #f0fff4;
+  color: #22543d;
+  border: 1px solid #9ae6b4;
+}
+
+.groups-feedback.error {
+  background: #fff5f5;
+  color: #c53030;
+  border: 1px solid #feb2b2;
+}
+
+.groups-feedback.warning {
+  background: #fffaf0;
+  color: #c05621;
+  border: 1px solid #fbd38d;
+}
+
+.groups-layout {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 1.5rem;
+}
+
+.groups-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.sidebar-section {
+  background: white;
+  padding: 1.5rem;
+  border-radius: 16px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.sidebar-section label {
+  font-size: 0.9rem;
+  color: #4a5568;
+  font-weight: 500;
+}
+
+.sidebar-section select {
+  width: 100%;
+  padding: 0.75rem;
+  border-radius: 10px;
+  border: 1px solid #e2e8f0;
+  font-size: 0.95rem;
+  color: #2d3748;
+}
+
+.section-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.groups-loading {
+  text-align: center;
+  color: #718096;
+  font-size: 0.9rem;
+}
+
+.groups-empty {
+  background: #f7fafc;
+  border: 1px dashed #cbd5f5;
+  border-radius: 12px;
+  padding: 1rem;
+  color: #4a5568;
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.groups-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 500px;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+
+.group-card {
+  background: #f8fafc;
+  border: 1px solid #edf2f7;
+  border-radius: 12px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  cursor: pointer;
+  transition: all 0.25s ease;
+  text-align: left;
+}
+
+.group-card:hover {
+  background: #edf2f7;
+}
+
+.group-card.active {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  border-color: transparent;
+  box-shadow: 0 8px 24px rgba(118, 75, 162, 0.35);
+}
+
+.group-name {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.group-meta {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.85rem;
+  color: inherit;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(102, 126, 234, 0.15);
+  color: #4c51bf;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.badge.success {
+  background: rgba(72, 187, 120, 0.2);
+  color: #2f855a;
+}
+
+.badge.info {
+  background: rgba(56, 161, 105, 0.2);
+  color: #276749;
+}
+
+.groups-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.group-section {
+  background: white;
+  padding: 1.75rem;
+  border-radius: 16px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.group-section h3 {
+  color: #2d3748;
+  font-size: 1.3rem;
+}
+
+.group-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-row label {
+  font-size: 0.9rem;
+  color: #4a5568;
+  font-weight: 600;
+}
+
+.form-row input,
+.form-row textarea,
+.group-info-grid input,
+.group-info-grid textarea,
+.participants-actions textarea,
+.participant-selector select,
+.invite-code input {
+  width: 100%;
+  padding: 0.75rem;
+  border-radius: 10px;
+  border: 1px solid #e2e8f0;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-row small {
+  color: #718096;
+  font-size: 0.8rem;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.form-actions .primary,
+.form-actions .secondary,
+.form-actions .danger,
+.participants-actions button,
+.invite-actions button,
+.group-section button {
+  border: none;
+  border-radius: 10px;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.25s ease;
+}
+
+.primary {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+}
+
+.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(118, 75, 162, 0.35);
+}
+
+.secondary {
+  background: #edf2f7;
+  color: #2d3748;
+}
+
+.secondary:hover {
+  background: #e2e8f0;
+}
+
+.danger {
+  background: #fed7d7;
+  color: #c53030;
+}
+
+.danger:hover {
+  background: #feb2b2;
+}
+
+.group-placeholder {
+  text-align: center;
+  color: #718096;
+  background: white;
+  padding: 2rem;
+  border-radius: 16px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.05);
+}
+
+.group-info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+}
+
+.group-details-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  font-size: 0.9rem;
+  color: #4a5568;
+}
+
+.settings-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: #2d3748;
+}
+
+.toggle input[type='checkbox'] {
+  width: 18px;
+  height: 18px;
+}
+
+.participants-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+}
+
+.participant-card {
+  border: 1px solid #edf2f7;
+  border-radius: 12px;
+  padding: 0.75rem;
+  background: #f8fafc;
+}
+
+.participant-name {
+  font-weight: 600;
+  color: #2d3748;
+  margin-bottom: 0.25rem;
+}
+
+.participant-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+  color: #4a5568;
+}
+
+.participants-actions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.participant-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.participant-selector button,
+.invite-actions button,
+.group-section button {
+  width: fit-content;
+}
+
+.invite-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.invite-code input {
+  background: #f7fafc;
+}
+
+.invite-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 1024px) {
+  .groups-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .groups-sidebar {
+    flex-direction: row;
+    overflow-x: auto;
+  }
+
+  .sidebar-section {
+    min-width: 280px;
+  }
+}
+
+@media (max-width: 768px) {
+  .groups-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .groups-header-actions {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .groups-header-actions button {
+    flex: 1;
+  }
+
+  .participants-actions {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,6 +6,7 @@ import FlowList from './components/FlowList';
 import MessagesCenter from './components/MessagesCenter';
 import Settings from './components/Settings';
 import WhatsAppInstances from './components/WhatsAppInstances';
+import GroupsManager from './components/GroupsManager';
 
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
 const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;
@@ -47,14 +48,21 @@ const Navigation = ({ currentView, onViewChange }) => {
           <span className="nav-icon">🎯</span>
           <span>Fluxos</span>
         </button>
-        <button 
+        <button
           className={`nav-item ${currentView === 'contacts' ? 'active' : ''}`}
           onClick={() => onViewChange('contacts')}
         >
           <span className="nav-icon">👥</span>
           <span>Contatos</span>
         </button>
-        <button 
+        <button
+          className={`nav-item ${currentView === 'groups' ? 'active' : ''}`}
+          onClick={() => onViewChange('groups')}
+        >
+          <span className="nav-icon">🧑‍🤝‍🧑</span>
+          <span>Grupos</span>
+        </button>
+        <button
           className={`nav-item ${currentView === 'messages' ? 'active' : ''}`}
           onClick={() => onViewChange('messages')}
         >
@@ -437,6 +445,10 @@ function App() {
               <h2>👥 Gerenciamento de Contatos</h2>
               <ContactsList />
             </section>
+          )}
+
+          {currentView === 'groups' && (
+            <GroupsManager />
           )}
 
           {currentView === 'messages' && (

--- a/frontend/src/components/GroupsManager.js
+++ b/frontend/src/components/GroupsManager.js
@@ -1,0 +1,785 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import axios from 'axios';
+
+const resolveServiceUrl = () => {
+  if (process.env.REACT_APP_API_BASE_URL) {
+    return process.env.REACT_APP_API_BASE_URL;
+  }
+
+  if (typeof window !== 'undefined') {
+    if (window.API_BASE_URL) {
+      return window.API_BASE_URL;
+    }
+
+    return `http://${window.location.hostname}:3002`;
+  }
+
+  return 'http://localhost:3002';
+};
+
+const SERVICE_URL = resolveServiceUrl();
+
+const parseParticipantsInput = (value) => {
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(/[\n,;]+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+};
+
+const formatParticipant = (participant) => {
+  if (!participant) {
+    return '';
+  }
+
+  if (participant.includes('@')) {
+    return participant;
+  }
+
+  return `${participant}@s.whatsapp.net`;
+};
+
+const getParticipantLabel = (participant) => {
+  if (!participant) {
+    return '';
+  }
+
+  if (participant.phone) {
+    return participant.phone;
+  }
+
+  if (participant.jid && participant.jid.includes('@')) {
+    return participant.jid.replace('@s.whatsapp.net', '');
+  }
+
+  return participant.jid || participant.id || '';
+};
+
+const GroupsManager = () => {
+  const [instances, setInstances] = useState([]);
+  const [instancesLoading, setInstancesLoading] = useState(true);
+  const [groupsLoading, setGroupsLoading] = useState(false);
+  const [groups, setGroups] = useState([]);
+  const [selectedInstance, setSelectedInstance] = useState('');
+  const [selectedGroupId, setSelectedGroupId] = useState('');
+  const [selectedGroup, setSelectedGroup] = useState(null);
+  const [feedback, setFeedback] = useState(null);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [createSubject, setCreateSubject] = useState('');
+  const [createParticipants, setCreateParticipants] = useState('');
+  const [creatingGroup, setCreatingGroup] = useState(false);
+  const [subjectInput, setSubjectInput] = useState('');
+  const [descriptionInput, setDescriptionInput] = useState('');
+  const [announcementOnly, setAnnouncementOnly] = useState(false);
+  const [restrictedInfo, setRestrictedInfo] = useState(false);
+  const [settingsUpdating, setSettingsUpdating] = useState(false);
+  const [addParticipantsInput, setAddParticipantsInput] = useState('');
+  const [removeParticipant, setRemoveParticipant] = useState('');
+  const [promoteParticipant, setPromoteParticipant] = useState('');
+  const [demoteParticipant, setDemoteParticipant] = useState('');
+  const [participantsUpdating, setParticipantsUpdating] = useState(false);
+  const [inviteCode, setInviteCode] = useState('');
+  const [inviteLoading, setInviteLoading] = useState(false);
+
+  const isAdmin = useMemo(
+    () => Boolean(selectedGroup?.permissions?.isAdmin),
+    [selectedGroup]
+  );
+
+  const handleError = (error, fallbackMessage) => {
+    const message = error?.response?.data?.error || error.message || fallbackMessage;
+    setFeedback({ type: 'error', message });
+  };
+
+  const fetchInstances = async () => {
+    setInstancesLoading(true);
+    try {
+      const { data } = await axios.get(`${SERVICE_URL}/status`);
+      const parsed = Object.entries(data || {}).map(([id, details]) => ({
+        id,
+        ...(details || {})
+      }));
+      setInstances(parsed);
+
+      if (!selectedInstance && parsed.length > 0) {
+        setSelectedInstance(parsed[0].id);
+      }
+    } catch (error) {
+      handleError(error, 'Não foi possível carregar as instâncias');
+    } finally {
+      setInstancesLoading(false);
+    }
+  };
+
+  const fetchGroups = async (instanceId, options = {}) => {
+    if (!instanceId) {
+      setGroups([]);
+      setSelectedGroupId('');
+      setSelectedGroup(null);
+      return;
+    }
+
+    setGroupsLoading(true);
+    try {
+      const params = {};
+      if (options.refresh) {
+        params.refresh = 'true';
+      }
+
+      const { data } = await axios.get(`${SERVICE_URL}/groups/${instanceId}`, { params });
+      const receivedGroups = data?.groups || [];
+      setGroups(receivedGroups);
+
+      if (receivedGroups.length === 0) {
+        setSelectedGroupId('');
+        setSelectedGroup(null);
+      } else if (!selectedGroupId || !receivedGroups.some((group) => (group.jid || group.id) === selectedGroupId)) {
+        const firstId = receivedGroups[0].jid || receivedGroups[0].id;
+        setSelectedGroupId(firstId);
+      }
+
+      if (data?.cache?.source === 'fallback') {
+        setFeedback({
+          type: 'warning',
+          message: 'Grupos carregados via fallback. Algumas ações podem exigir atualização manual.'
+        });
+      }
+    } catch (error) {
+      handleError(error, 'Erro ao carregar grupos');
+      setGroups([]);
+      setSelectedGroupId('');
+      setSelectedGroup(null);
+    } finally {
+      setGroupsLoading(false);
+    }
+  };
+
+  const refreshAfterAction = async (groupId) => {
+    if (!selectedInstance) {
+      return;
+    }
+    await fetchGroups(selectedInstance, { refresh: true });
+    if (groupId) {
+      setSelectedGroupId(groupId);
+    }
+  };
+
+  const handleCreateGroup = async (event) => {
+    event.preventDefault();
+    if (!selectedInstance) {
+      setFeedback({ type: 'error', message: 'Selecione uma instância antes de criar grupos' });
+      return;
+    }
+
+    const participantsList = parseParticipantsInput(createParticipants);
+
+    setCreatingGroup(true);
+    try {
+      const { data } = await axios.post(`${SERVICE_URL}/groups/${selectedInstance}`, {
+        subject: createSubject.trim(),
+        participants: participantsList.map(formatParticipant)
+      });
+
+      setFeedback({
+        type: 'success',
+        message: `Grupo "${data?.group?.name || createSubject}" criado com sucesso`
+      });
+
+      setCreateSubject('');
+      setCreateParticipants('');
+      setShowCreateForm(false);
+      await refreshAfterAction(data?.group?.jid || data?.groupId);
+    } catch (error) {
+      handleError(error, 'Erro ao criar grupo');
+    } finally {
+      setCreatingGroup(false);
+    }
+  };
+
+  const handleUpdateSubject = async () => {
+    if (!selectedInstance || !selectedGroup) {
+      return;
+    }
+
+    if (!subjectInput.trim()) {
+      setFeedback({ type: 'error', message: 'Informe um assunto válido' });
+      return;
+    }
+
+    try {
+      await axios.patch(`${SERVICE_URL}/groups/${selectedInstance}/${selectedGroup.jid}/subject`, {
+        subject: subjectInput.trim()
+      });
+
+      setFeedback({ type: 'success', message: 'Assunto atualizado com sucesso' });
+      await refreshAfterAction(selectedGroup.jid);
+    } catch (error) {
+      handleError(error, 'Erro ao atualizar assunto');
+    }
+  };
+
+  const handleUpdateDescription = async () => {
+    if (!selectedInstance || !selectedGroup) {
+      return;
+    }
+
+    try {
+      await axios.patch(`${SERVICE_URL}/groups/${selectedInstance}/${selectedGroup.jid}/description`, {
+        description: descriptionInput
+      });
+      setFeedback({ type: 'success', message: 'Descrição atualizada' });
+      await refreshAfterAction(selectedGroup.jid);
+    } catch (error) {
+      handleError(error, 'Erro ao atualizar descrição');
+    }
+  };
+
+  const handleSettingChange = async (type, value) => {
+    if (!selectedInstance || !selectedGroup) {
+      return;
+    }
+
+    setSettingsUpdating(true);
+    try {
+      const payload = type === 'announcement' ? { announcement: value } : { locked: value };
+      await axios.patch(`${SERVICE_URL}/groups/${selectedInstance}/${selectedGroup.jid}/settings`, payload);
+      setFeedback({ type: 'success', message: 'Configurações atualizadas' });
+      await refreshAfterAction(selectedGroup.jid);
+    } catch (error) {
+      handleError(error, 'Erro ao atualizar configurações');
+      // Revert state on error
+      if (type === 'announcement') {
+        setAnnouncementOnly(Boolean(selectedGroup?.settings?.announcement));
+      } else {
+        setRestrictedInfo(Boolean(selectedGroup?.settings?.locked));
+      }
+    } finally {
+      setSettingsUpdating(false);
+    }
+  };
+
+  const handleParticipantsAction = async (action, list) => {
+    if (!selectedInstance || !selectedGroup) {
+      return;
+    }
+
+    if (!list.length) {
+      setFeedback({ type: 'error', message: 'Informe ao menos um participante' });
+      return;
+    }
+
+    setParticipantsUpdating(true);
+    try {
+      await axios.post(`${SERVICE_URL}/groups/${selectedInstance}/${selectedGroup.jid}/participants`, {
+        action,
+        participants: list
+      });
+
+      const actionLabel = {
+        add: 'adicionados',
+        remove: 'removidos',
+        promote: 'promovidos',
+        demote: 'rebaixados'
+      }[action];
+
+      setFeedback({ type: 'success', message: `Participantes ${actionLabel} com sucesso` });
+
+      setAddParticipantsInput('');
+      setRemoveParticipant('');
+      setPromoteParticipant('');
+      setDemoteParticipant('');
+
+      await refreshAfterAction(selectedGroup.jid);
+    } catch (error) {
+      handleError(error, 'Erro ao atualizar participantes');
+    } finally {
+      setParticipantsUpdating(false);
+    }
+  };
+
+  const handleLeaveGroup = async () => {
+    if (!selectedInstance || !selectedGroup) {
+      return;
+    }
+
+    if (!window.confirm('Tem certeza que deseja sair deste grupo?')) {
+      return;
+    }
+
+    try {
+      await axios.post(`${SERVICE_URL}/groups/${selectedInstance}/${selectedGroup.jid}/leave`);
+      setFeedback({ type: 'success', message: 'Instância removida do grupo' });
+      await refreshAfterAction(null);
+    } catch (error) {
+      handleError(error, 'Erro ao sair do grupo');
+    }
+  };
+
+  const handleFetchInviteCode = async () => {
+    if (!selectedInstance || !selectedGroup) {
+      return;
+    }
+
+    setInviteLoading(true);
+    try {
+      const { data } = await axios.get(`${SERVICE_URL}/groups/${selectedInstance}/${selectedGroup.jid}/invite-code`);
+      setInviteCode(data?.code || '');
+      setFeedback({ type: 'success', message: 'Código de convite atualizado' });
+    } catch (error) {
+      handleError(error, 'Erro ao obter código de convite');
+    } finally {
+      setInviteLoading(false);
+    }
+  };
+
+  const handleRevokeInvite = async () => {
+    if (!selectedInstance || !selectedGroup) {
+      return;
+    }
+
+    setInviteLoading(true);
+    try {
+      const { data } = await axios.post(`${SERVICE_URL}/groups/${selectedInstance}/${selectedGroup.jid}/revoke-invite`);
+      setInviteCode(data?.code || '');
+      setFeedback({ type: 'success', message: 'Convite revogado. Novo código gerado.' });
+    } catch (error) {
+      handleError(error, 'Erro ao revogar convite');
+    } finally {
+      setInviteLoading(false);
+    }
+  };
+
+  const handleCopyInvite = async () => {
+    if (!inviteCode) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(inviteCode);
+      setFeedback({ type: 'success', message: 'Código copiado para a área de transferência' });
+    } catch (error) {
+      handleError(error, 'Não foi possível copiar o código');
+    }
+  };
+
+  useEffect(() => {
+    fetchInstances();
+  }, []);
+
+  useEffect(() => {
+    fetchGroups(selectedInstance);
+  }, [selectedInstance]);
+
+  useEffect(() => {
+    if (!selectedGroupId) {
+      setSelectedGroup(null);
+      return;
+    }
+
+    const group = groups.find((item) => (item.jid || item.id) === selectedGroupId);
+    setSelectedGroup(group || null);
+  }, [groups, selectedGroupId]);
+
+  useEffect(() => {
+    if (!selectedGroup) {
+      setSubjectInput('');
+      setDescriptionInput('');
+      setAnnouncementOnly(false);
+      setRestrictedInfo(false);
+      setInviteCode('');
+      return;
+    }
+
+    setSubjectInput(selectedGroup.name || '');
+    setDescriptionInput(selectedGroup.description || '');
+    setAnnouncementOnly(Boolean(selectedGroup?.settings?.announcement));
+    setRestrictedInfo(Boolean(selectedGroup?.settings?.locked));
+    setInviteCode(selectedGroup?.inviteCode || '');
+  }, [selectedGroup]);
+
+  return (
+    <div className="groups-manager">
+      <div className="groups-header">
+        <div>
+          <h2>🧑‍🤝‍🧑 Gerenciamento de Grupos</h2>
+          <p>Crie e administre grupos WhatsApp diretamente pelo WhatsFlow</p>
+        </div>
+        <div className="groups-header-actions">
+          <button
+            className="refresh-btn"
+            onClick={() => fetchGroups(selectedInstance, { refresh: true })}
+            disabled={groupsLoading || !selectedInstance}
+          >
+            🔄 Atualizar Grupos
+          </button>
+          <button
+            className="create-group-btn"
+            onClick={() => setShowCreateForm((prev) => !prev)}
+            disabled={!selectedInstance}
+          >
+            {showCreateForm ? '➖ Fechar' : '➕ Novo Grupo'}
+          </button>
+        </div>
+      </div>
+
+      {feedback && (
+        <div className={`groups-feedback ${feedback.type}`}>
+          {feedback.message}
+        </div>
+      )}
+
+      <div className="groups-layout">
+        <aside className="groups-sidebar">
+          <div className="sidebar-section">
+            <label>Instância conectada</label>
+            {instancesLoading ? (
+              <div className="groups-loading">Carregando instâncias...</div>
+            ) : (
+              <select
+                value={selectedInstance}
+                onChange={(event) => setSelectedInstance(event.target.value)}
+              >
+                <option value="">Selecione uma instância</option>
+                {instances.map((instance) => (
+                  <option key={instance.id} value={instance.id}>
+                    {instance.id} {instance.connected ? '✅' : instance.connecting ? '⏳' : '⚠️'}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+
+          <div className="sidebar-section">
+            <div className="section-title">
+              <h3>Grupos</h3>
+              <span className="badge">{groups.length}</span>
+            </div>
+
+            {groupsLoading ? (
+              <div className="groups-loading">Carregando grupos...</div>
+            ) : groups.length === 0 ? (
+              <div className="groups-empty">
+                {selectedInstance
+                  ? 'Nenhum grupo encontrado. Crie um novo grupo ou sincronize novamente.'
+                  : 'Selecione uma instância para visualizar os grupos.'}
+              </div>
+            ) : (
+              <div className="groups-list">
+                {groups.map((group) => {
+                  const groupKey = group.jid || group.id;
+                  const isActive = groupKey === selectedGroupId;
+                  return (
+                    <button
+                      key={groupKey}
+                      className={`group-card ${isActive ? 'active' : ''}`}
+                      onClick={() => setSelectedGroupId(groupKey)}
+                    >
+                      <div className="group-name">{group.name}</div>
+                      <div className="group-meta">
+                        <span>👤 {group.participantCount || 0}</span>
+                        {group.permissions?.isAdmin ? <span className="badge success">Admin</span> : <span className="badge">Membro</span>}
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </aside>
+
+        <section className="groups-content">
+          {showCreateForm && (
+            <div className="group-section">
+              <h3>➕ Criar novo grupo</h3>
+              <form className="group-form" onSubmit={handleCreateGroup}>
+                <div className="form-row">
+                  <label>Nome do grupo</label>
+                  <input
+                    type="text"
+                    value={createSubject}
+                    onChange={(event) => setCreateSubject(event.target.value)}
+                    placeholder="Nome do grupo"
+                    required
+                  />
+                </div>
+                <div className="form-row">
+                  <label>Participantes iniciais</label>
+                  <textarea
+                    value={createParticipants}
+                    onChange={(event) => setCreateParticipants(event.target.value)}
+                    placeholder="Insira telefones separados por vírgula ou quebra de linha"
+                    rows={3}
+                  />
+                  <small>Você pode deixar em branco e adicionar participantes depois.</small>
+                </div>
+                <div className="form-actions">
+                  <button type="submit" className="primary" disabled={creatingGroup}>
+                    {creatingGroup ? 'Criando...' : 'Criar grupo'}
+                  </button>
+                </div>
+              </form>
+            </div>
+          )}
+
+          {!selectedGroup && !groupsLoading && (
+            <div className="group-placeholder">
+              <h3>Selecione um grupo para visualizar detalhes</h3>
+              <p>Utilize a lista ao lado para escolher o grupo que deseja gerenciar.</p>
+            </div>
+          )}
+
+          {selectedGroup && (
+            <>
+              <div className="group-section">
+                <h3>📋 Informações do grupo</h3>
+                <div className="group-info-grid">
+                  <div>
+                    <label>Nome</label>
+                    <input
+                      type="text"
+                      value={subjectInput}
+                      onChange={(event) => setSubjectInput(event.target.value)}
+                      disabled={!isAdmin}
+                    />
+                  </div>
+                  <div>
+                    <label>Descrição</label>
+                    <textarea
+                      value={descriptionInput}
+                      onChange={(event) => setDescriptionInput(event.target.value)}
+                      rows={3}
+                      disabled={!isAdmin}
+                    />
+                  </div>
+                </div>
+                <div className="form-actions">
+                  <button
+                    className="primary"
+                    onClick={handleUpdateSubject}
+                    disabled={!isAdmin}
+                  >
+                    Atualizar assunto
+                  </button>
+                  <button
+                    className="secondary"
+                    onClick={handleUpdateDescription}
+                    disabled={!isAdmin}
+                  >
+                    Atualizar descrição
+                  </button>
+                </div>
+
+                <div className="group-details-grid">
+                  <div>
+                    <strong>JID:</strong> {selectedGroup.jid}
+                  </div>
+                  <div>
+                    <strong>Participantes:</strong> {selectedGroup.participantCount || 0}
+                  </div>
+                  <div>
+                    <strong>Permissão:</strong> {isAdmin ? 'Administrador' : 'Membro'}
+                  </div>
+                  {selectedGroup.createdAt && (
+                    <div>
+                      <strong>Criado em:</strong> {new Date(selectedGroup.createdAt).toLocaleString()}
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <div className="group-section">
+                <h3>⚙️ Configurações</h3>
+                <div className="settings-grid">
+                  <label className="toggle">
+                    <input
+                      type="checkbox"
+                      checked={announcementOnly}
+                      onChange={(event) => {
+                        const value = event.target.checked;
+                        setAnnouncementOnly(value);
+                        handleSettingChange('announcement', value);
+                      }}
+                      disabled={!isAdmin || settingsUpdating}
+                    />
+                    <span>Apenas administradores podem enviar mensagens</span>
+                  </label>
+
+                  <label className="toggle">
+                    <input
+                      type="checkbox"
+                      checked={restrictedInfo}
+                      onChange={(event) => {
+                        const value = event.target.checked;
+                        setRestrictedInfo(value);
+                        handleSettingChange('locked', value);
+                      }}
+                      disabled={!isAdmin || settingsUpdating}
+                    />
+                    <span>Apenas administradores podem editar dados do grupo</span>
+                  </label>
+                </div>
+              </div>
+
+              <div className="group-section">
+                <h3>👥 Participantes</h3>
+                <div className="participants-grid">
+                  {selectedGroup.participants && selectedGroup.participants.length > 0 ? (
+                    selectedGroup.participants.map((participant) => (
+                      <div key={participant.jid} className="participant-card">
+                        <div className="participant-name">{participant.name || getParticipantLabel(participant)}</div>
+                        <div className="participant-meta">
+                          <span>{participant.jid}</span>
+                          {participant.isAdmin && <span className="badge success">Admin</span>}
+                          {participant.isMe && <span className="badge info">Você</span>}
+                        </div>
+                      </div>
+                    ))
+                  ) : (
+                    <div className="groups-empty">Nenhum participante disponível</div>
+                  )}
+                </div>
+
+                {isAdmin ? (
+                  <div className="participants-actions">
+                    <div>
+                      <label>Adicionar participantes</label>
+                      <textarea
+                        rows={2}
+                        placeholder="Ex: 5511999999999, 558199999999"
+                        value={addParticipantsInput}
+                        onChange={(event) => setAddParticipantsInput(event.target.value)}
+                      />
+                      <button
+                        className="primary"
+                        onClick={() => handleParticipantsAction('add', parseParticipantsInput(addParticipantsInput).map(formatParticipant))}
+                        disabled={participantsUpdating}
+                      >
+                        Adicionar
+                      </button>
+                    </div>
+
+                    <div className="participant-selector">
+                      <label>Remover participante</label>
+                      <select
+                        value={removeParticipant}
+                        onChange={(event) => setRemoveParticipant(event.target.value)}
+                      >
+                        <option value="">Selecione</option>
+                        {selectedGroup.participants
+                          ?.filter((participant) => !participant.isMe)
+                          .map((participant) => (
+                            <option key={`remove-${participant.jid}`} value={participant.jid}>
+                              {participant.name || getParticipantLabel(participant)}
+                            </option>
+                          ))}
+                      </select>
+                      <button
+                        className="danger"
+                        onClick={() => handleParticipantsAction('remove', removeParticipant ? [removeParticipant] : [])}
+                        disabled={!removeParticipant || participantsUpdating}
+                      >
+                        Remover
+                      </button>
+                    </div>
+
+                    <div className="participant-selector">
+                      <label>Promover para admin</label>
+                      <select
+                        value={promoteParticipant}
+                        onChange={(event) => setPromoteParticipant(event.target.value)}
+                      >
+                        <option value="">Selecione</option>
+                        {selectedGroup.participants
+                          ?.filter((participant) => !participant.isAdmin)
+                          .map((participant) => (
+                            <option key={`promote-${participant.jid}`} value={participant.jid}>
+                              {participant.name || getParticipantLabel(participant)}
+                            </option>
+                          ))}
+                      </select>
+                      <button
+                        className="secondary"
+                        onClick={() => handleParticipantsAction('promote', promoteParticipant ? [promoteParticipant] : [])}
+                        disabled={!promoteParticipant || participantsUpdating}
+                      >
+                        Promover
+                      </button>
+                    </div>
+
+                    <div className="participant-selector">
+                      <label>Remover privilégios de admin</label>
+                      <select
+                        value={demoteParticipant}
+                        onChange={(event) => setDemoteParticipant(event.target.value)}
+                      >
+                        <option value="">Selecione</option>
+                        {selectedGroup.participants
+                          ?.filter((participant) => participant.isAdmin && !participant.isSuperAdmin)
+                          .map((participant) => (
+                            <option key={`demote-${participant.jid}`} value={participant.jid}>
+                              {participant.name || getParticipantLabel(participant)}
+                            </option>
+                          ))}
+                      </select>
+                      <button
+                        className="secondary"
+                        onClick={() => handleParticipantsAction('demote', demoteParticipant ? [demoteParticipant] : [])}
+                        disabled={!demoteParticipant || participantsUpdating}
+                      >
+                        Rebaixar
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="groups-empty">
+                    Você precisa ser administrador do grupo para gerenciar participantes.
+                  </div>
+                )}
+              </div>
+
+              <div className="group-section">
+                <h3>🔐 Convites</h3>
+                {isAdmin ? (
+                  <div className="invite-panel">
+                    <div className="invite-code">
+                      <label>Código atual</label>
+                      <input type="text" value={inviteCode} readOnly placeholder="Nenhum código carregado" />
+                    </div>
+                    <div className="invite-actions">
+                      <button onClick={handleFetchInviteCode} disabled={inviteLoading}>
+                        {inviteLoading ? 'Carregando...' : 'Obter código'}
+                      </button>
+                      <button onClick={handleRevokeInvite} disabled={inviteLoading} className="danger">
+                        Revogar convite
+                      </button>
+                      <button onClick={handleCopyInvite} disabled={!inviteCode} className="secondary">
+                        Copiar código
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="groups-empty">
+                    Apenas administradores podem visualizar ou alterar códigos de convite.
+                  </div>
+                )}
+              </div>
+
+              <div className="group-section">
+                <h3>🚪 Sair do grupo</h3>
+                <p>Remova a instância atual deste grupo. Esta ação pode ser revertida apenas mediante convite.</p>
+                <button className="danger" onClick={handleLeaveGroup}>
+                  Sair do grupo
+                </button>
+              </div>
+            </>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default GroupsManager;


### PR DESCRIPTION
## Summary
- implement group metadata caching, admin validation and new Baileys endpoints for group lifecycle actions
- add a dedicated React GroupsManager view with creation, settings, participant and invite management controls
- document available group operations and error scenarios for the service

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8db823504832f9160049535df1bbf