### PR TITLE
Remove stray text causing syntax error

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -9266,7 +9266,6 @@ class MessageScheduler:
                 print(f"❌ {error_msg}")
                 return False, error_msg
 
-update-sql-schema-and-functions
             message_type = normalize_scheduled_message_type(message_type)
             if message_type not in SCHEDULED_MESSAGE_ALLOWED_TYPES:
                 error_msg = f"Tipo de mensagem não suportado: {message_type}"


### PR DESCRIPTION
## Summary
- remove a stray `update-sql-schema-and-functions` marker left in `_send_message_to_group`
- ensure the file compiles without syntax errors

## Testing
- python -m py_compile whatsflow-real.py

------
https://chatgpt.com/codex/tasks/task_e_68c8eeeb484c832fbb9a3a96462dd666