### PR TITLE
feat: refresh WhatsFlow dashboard layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,4 +1,20 @@
-/* Global Styles */
+/* === WhatsFlow Professional Layout === */
+:root {
+  --primary: #128c7e;
+  --primary-dark: #075e54;
+  --primary-light: #25d366;
+  --accent-warning: #f59e0b;
+  --accent-danger: #ef4444;
+  --bg-primary: #f0f2f5;
+  --bg-secondary: #ffffff;
+  --bg-muted: #e6f7f2;
+  --text-primary: #111b21;
+  --text-secondary: #667781;
+  --border: #dfe5ec;
+  --shadow: 0 20px 45px rgba(7, 94, 84, 0.16);
+  --shadow-soft: 0 12px 30px rgba(7, 94, 84, 0.12);
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -6,581 +22,680 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: linear-gradient(135deg, var(--primary-dark) 0%, var(--primary) 100%);
+  color: var(--text-primary);
   min-height: 100vh;
+}
+
+button {
+  font-family: inherit;
 }
 
 .app {
   min-height: 100vh;
-  color: #333;
 }
 
-/* Header */
-.app-header {
-  background: rgba(255, 255, 255, 0.95);
-  backdrop-filter: blur(10px);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-  padding: 1rem 0;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+.professional-app {
+  position: relative;
 }
 
-.header-content {
-  max-width: 1200px;
+.app-surface {
+  padding: 2.5rem 1.5rem 4rem;
+}
+
+.app-container {
+  max-width: 1280px;
   margin: 0 auto;
-  padding: 0 2rem;
+}
+
+.app-hero {
   text-align: center;
-}
-
-.header-content h1 {
-  font-size: 2.5rem;
-  font-weight: 700;
-  color: #2d3748;
-  margin-bottom: 0.5rem;
-}
-
-.header-content p {
-  font-size: 1.1rem;
-  color: #666;
-}
-
-/* Navigation */
-.main-navigation {
-  background: rgba(255, 255, 255, 0.9);
-  backdrop-filter: blur(10px);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-  padding: 0.5rem 0;
-}
-
-.nav-items {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 2rem;
-  display: flex;
-  gap: 0.5rem;
-}
-
-.nav-item {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1.5rem;
-  background: transparent;
-  border: none;
-  border-radius: 8px;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  font-size: 0.95rem;
-  font-weight: 500;
-  color: #666;
-}
-
-.nav-item:hover {
-  background: rgba(102, 126, 234, 0.1);
-  color: #667eea;
-}
-
-.nav-item.active {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
-}
-
-.nav-icon {
-  font-size: 1.2rem;
-}
-
-/* Main Content */
-.app-main {
-  padding: 2rem 0;
-}
-
-.container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 2rem;
-}
-
-/* WhatsApp Connection */
-.whatsapp-connection {
-  background: white;
-  border-radius: 16px;
-  padding: 2rem;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+  color: #ffffff;
   margin-bottom: 2rem;
 }
 
-.connection-header {
+.app-hero h1 {
+  font-size: 2.75rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin-bottom: 0.75rem;
+}
+
+.app-hero p {
+  font-size: 1.05rem;
+  opacity: 0.85;
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 1.25rem;
+  padding: 0.6rem 1.25rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  font-size: 0.9rem;
+  font-weight: 600;
+  backdrop-filter: blur(12px);
+}
+
+.app-nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  border-radius: 1rem;
+  margin-bottom: 2rem;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  backdrop-filter: blur(14px);
+}
+
+.nav-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.65rem 1.25rem;
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+}
+
+.nav-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px rgba(7, 94, 84, 0.35);
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.nav-button.active {
+  background: linear-gradient(135deg, var(--primary-light) 0%, var(--primary) 100%);
+  color: #ffffff;
+  box-shadow: 0 14px 32px rgba(7, 94, 84, 0.35);
+}
+
+.nav-button-icon {
+  font-size: 1.1rem;
+}
+
+.nav-button-label {
+  letter-spacing: 0.01em;
+}
+
+.app-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.view-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.view-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.card {
+  background: var(--bg-secondary);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-soft);
+  position: relative;
+}
+
+.card-header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
+  gap: 1.5rem;
   margin-bottom: 1.5rem;
 }
 
-.connection-header h2 {
-  font-size: 1.5rem;
-  color: #2d3748;
+.card-header h2,
+.card-header h3 {
+  color: var(--text-primary);
+  font-weight: 700;
+  margin-bottom: 0.35rem;
+}
+
+.card-subtitle {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  max-width: 520px;
 }
 
 .status-indicator {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.5rem 1rem;
-  border-radius: 25px;
-  font-weight: 500;
+  padding: 0.55rem 1.05rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  border: 1px solid transparent;
+  background: rgba(17, 27, 33, 0.05);
+  color: var(--text-secondary);
 }
 
-.status-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
+.status-indicator .status-text {
+  letter-spacing: 0.02em;
 }
 
 .status-indicator.connected {
-  background: #f0fff4;
-  color: #22543d;
-}
-
-.status-indicator.connected .status-dot {
-  background: #48bb78;
+  background: rgba(37, 211, 102, 0.12);
+  border-color: rgba(37, 211, 102, 0.35);
+  color: var(--primary-light);
 }
 
 .status-indicator.disconnected {
-  background: #fffaf0;
-  color: #c05621;
-}
-
-.status-indicator.disconnected .status-dot {
-  background: #ed8936;
+  background: rgba(245, 158, 11, 0.12);
+  border-color: rgba(245, 158, 11, 0.35);
+  color: var(--accent-warning);
 }
 
 .status-indicator.error {
-  background: #fed7d7;
-  color: #c53030;
+  background: rgba(239, 68, 68, 0.15);
+  border-color: rgba(239, 68, 68, 0.35);
+  color: var(--accent-danger);
 }
 
-.status-indicator.error .status-dot {
-  background: #e53e3e;
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentColor;
 }
 
-/* Badges */
-.success-badge, .warning-badge, .error-badge, .demo-badge {
-  padding: 1rem;
-  border-radius: 8px;
-  margin-bottom: 1rem;
-  font-weight: 500;
-}
-
-.success-badge {
-  background: #f0fff4;
-  color: #22543d;
-  border: 1px solid #9ae6b4;
-}
-
-.warning-badge {
-  background: #fffaf0;
-  color: #c05621;
-  border: 1px solid #fbd38d;
-}
-
-.error-badge {
-  background: #fed7d7;
-  color: #c53030;
-  border: 1px solid #fc8181;
+.status-tag {
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(17, 27, 33, 0.1);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
 .demo-badge {
-  background: #ebf8ff;
-  color: #2c5282;
-  border: 1px solid #90cdf4;
+  margin-bottom: 1.25rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, rgba(37, 211, 102, 0.12) 0%, rgba(66, 153, 225, 0.12) 100%);
+  border: 1px dashed rgba(37, 211, 102, 0.4);
+  color: var(--primary-dark);
+  font-weight: 600;
   text-align: center;
 }
 
-/* QR Code */
-.qr-section {
-  text-align: center;
+.connection-success {
+  margin-top: 1rem;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, rgba(37, 211, 102, 0.12) 0%, rgba(18, 140, 126, 0.1) 100%);
+  border: 1px solid rgba(37, 211, 102, 0.3);
+  color: var(--primary-dark);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.connection-body {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.success-badge,
+.warning-badge,
+.error-badge {
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+
+.success-badge {
+  background: linear-gradient(135deg, rgba(37, 211, 102, 0.1) 0%, rgba(18, 140, 126, 0.15) 100%);
+  border-color: rgba(37, 211, 102, 0.35);
+  color: var(--primary-dark);
+}
+
+.warning-badge {
+  background: linear-gradient(135deg, rgba(245, 158, 11, 0.12) 0%, rgba(250, 204, 21, 0.12) 100%);
+  border-color: rgba(245, 158, 11, 0.35);
+  color: #b45309;
+}
+
+.error-badge {
+  background: linear-gradient(135deg, rgba(239, 68, 68, 0.15) 0%, rgba(248, 113, 113, 0.12) 100%);
+  border-color: rgba(239, 68, 68, 0.35);
+  color: #991b1b;
 }
 
 .qr-display {
-  margin: 2rem 0;
-}
-
-.qr-display h3 {
-  color: #2d3748;
-  margin-bottom: 1rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
 }
 
 .qr-container {
   display: flex;
   justify-content: center;
-  margin: 1rem 0;
 }
 
 .qr-code {
-  padding: 1rem;
-  background: white;
-  border-radius: 12px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  padding: 1.25rem;
+  border-radius: 1.25rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-soft);
 }
 
 .qr-image {
   display: block;
-  border-radius: 8px;
+  border-radius: 0.75rem;
 }
 
 .qr-instructions {
-  color: #666;
+  color: var(--text-secondary);
   font-size: 0.9rem;
-  margin-top: 1rem;
+}
+
+.button-group {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.85rem;
+}
+
+.connect-button,
+.demo-button {
+  padding: 0.85rem 1.75rem;
+  border-radius: 0.9rem;
+  border: none;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  color: #ffffff;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .connect-button {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
-  border: none;
-  padding: 12px 24px;
-  border-radius: 8px;
-  font-size: 1rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.3s ease;
-}
-
-.connect-button:hover:not(:disabled) {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
-}
-
-.connect-button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
+  background: linear-gradient(135deg, var(--primary-dark) 0%, var(--primary) 100%);
+  box-shadow: 0 18px 35px rgba(7, 94, 84, 0.35);
 }
 
 .demo-button {
-  background: linear-gradient(135deg, #48bb78 0%, #38a169 100%);
-  color: white;
-  border: none;
-  padding: 12px 24px;
-  border-radius: 8px;
-  font-size: 1rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  margin-left: 1rem;
+  background: linear-gradient(135deg, #22c55e 0%, var(--primary-light) 100%);
+  box-shadow: 0 18px 35px rgba(34, 197, 94, 0.35);
 }
 
+.connect-button:hover:not(:disabled),
 .demo-button:hover:not(:disabled) {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(72, 187, 120, 0.4);
 }
 
+.connect-button:disabled,
 .demo-button:disabled {
   opacity: 0.6;
   cursor: not-allowed;
 }
 
-.button-group {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-/* Connected Info */
-.connected-info {
+.loading {
   text-align: center;
-}
-
-.user-info {
-  color: #666;
-  margin-top: 0.5rem;
-}
-
-/* Dashboard */
-.dashboard-section, .contacts-section, .features-preview, .messages-section {
-  margin-bottom: 2rem;
-}
-
-.dashboard-section h2, .contacts-section h3, .features-preview h2, .messages-section h2 {
-  color: #2d3748;
-  margin-bottom: 1.5rem;
-  font-size: 1.8rem;
-}
-
-/* Stats Grid */
-.dashboard-stats {
-  background: white;
-  border-radius: 16px;
+  color: var(--text-secondary);
   padding: 2rem;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+  font-weight: 500;
+}
+
+.stats-card {
+  padding: 1.5rem 1.75rem;
 }
 
 .stats-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1.5rem;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .stat-card {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  padding: 1.5rem;
-  background: linear-gradient(135deg, #f7fafc 0%, #edf2f7 100%);
-  border-radius: 12px;
-  border: 1px solid #e2e8f0;
+  gap: 1.1rem;
+  padding: 1.1rem 1.4rem;
+  border-radius: 1rem;
+  border: 1px solid var(--border);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95) 0%, rgba(230, 247, 242, 0.9) 100%);
+  box-shadow: var(--shadow-soft);
 }
 
 .stat-icon {
-  font-size: 2rem;
-  width: 60px;
-  height: 60px;
+  width: 56px;
+  height: 56px;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, var(--primary-dark) 0%, var(--primary) 100%);
+  color: #ffffff;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: white;
-  border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  font-size: 1.6rem;
+  flex-shrink: 0;
 }
 
 .stat-content h3 {
   font-size: 2rem;
-  font-weight: 700;
-  color: #2d3748;
+  font-weight: 800;
+  color: var(--primary-dark);
   margin-bottom: 0.25rem;
 }
 
 .stat-content p {
-  color: #666;
+  color: var(--text-secondary);
   font-size: 0.9rem;
 }
 
-/* Contacts */
-.contacts-list {
-  background: white;
-  border-radius: 16px;
-  padding: 2rem;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+.contacts-card .card-header {
+  margin-bottom: 1.25rem;
 }
 
 .contacts-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 .contact-card {
   display: flex;
-  align-items: center;
   gap: 1rem;
-  padding: 1rem;
-  border: 1px solid #e2e8f0;
-  border-radius: 12px;
-  transition: all 0.3s ease;
+  padding: 1rem 1.1rem;
+  border-radius: 1rem;
+  border: 1px solid var(--border);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95) 0%, rgba(232, 246, 241, 0.9) 100%);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .contact-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-soft);
 }
 
 .contact-avatar {
-  width: 50px;
-  height: 50px;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
+  width: 56px;
+  height: 56px;
   border-radius: 50%;
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-light) 100%);
+  color: #ffffff;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-weight: 600;
-  font-size: 1.2rem;
+  font-weight: 700;
+  font-size: 1.3rem;
 }
 
 .contact-info h4 {
-  color: #2d3748;
-  margin-bottom: 0.25rem;
+  color: var(--text-primary);
+  font-weight: 700;
+  margin-bottom: 0.35rem;
 }
 
 .contact-info p {
-  color: #666;
+  color: var(--text-secondary);
   font-size: 0.9rem;
   margin-bottom: 0.5rem;
 }
 
 .contact-tags {
   display: flex;
-  gap: 0.25rem;
   flex-wrap: wrap;
+  gap: 0.4rem;
 }
 
 .tag {
-  background: #e6fffa;
-  color: #234e52;
-  padding: 0.2rem 0.5rem;
-  border-radius: 12px;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(18, 140, 126, 0.12);
+  color: var(--primary-dark);
   font-size: 0.75rem;
-  border: 1px solid #b2f5ea;
+  font-weight: 600;
 }
 
-/* Flow List */
+.empty-state {
+  text-align: center;
+  padding: 3rem 1.5rem;
+  border-radius: 1rem;
+  border: 1px dashed var(--border);
+  color: var(--text-secondary);
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.empty-state .empty-icon {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+
 .flow-list {
-  background: white;
-  border-radius: 16px;
-  padding: 2rem;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
 .flow-list-header {
   display: flex;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
   align-items: center;
-  margin-bottom: 2rem;
-}
-
-.flow-list-header h2 {
-  color: #2d3748;
-  font-size: 1.8rem;
 }
 
 .create-flow-button {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
+  padding: 0.85rem 1.6rem;
+  border-radius: 0.85rem;
   border: none;
-  padding: 12px 24px;
-  border-radius: 8px;
-  font-size: 1rem;
-  font-weight: 500;
+  background: linear-gradient(135deg, var(--primary-dark) 0%, var(--primary) 100%);
+  color: #ffffff;
+  font-weight: 600;
   cursor: pointer;
-  transition: all 0.3s ease;
+  box-shadow: 0 18px 35px rgba(7, 94, 84, 0.3);
+  transition: transform 0.3s ease;
 }
 
 .create-flow-button:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
 }
 
 .flows-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-  gap: 1.5rem;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
 
 .flow-card {
-  border: 1px solid #e2e8f0;
-  border-radius: 12px;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
   padding: 1.5rem;
-  transition: all 0.3s ease;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95) 0%, rgba(230, 247, 242, 0.9) 100%);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .flow-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-soft);
 }
 
 .flow-card-header {
   display: flex;
   justify-content: space-between;
+  gap: 1rem;
   align-items: flex-start;
-  margin-bottom: 1rem;
+  margin-bottom: 1.25rem;
 }
 
 .flow-info h3 {
-  color: #2d3748;
-  margin-bottom: 0.5rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 0.35rem;
 }
 
 .flow-info p {
-  color: #666;
+  color: var(--text-secondary);
   font-size: 0.9rem;
 }
 
 .flow-status {
-  padding: 0.25rem 0.75rem;
-  border-radius: 12px;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-weight: 600;
   font-size: 0.8rem;
-  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
 .flow-status.active {
-  background: #f0fff4;
-  color: #22543d;
+  background: rgba(37, 211, 102, 0.15);
+  color: var(--primary-dark);
 }
 
 .flow-status.inactive {
-  background: #fffaf0;
-  color: #c05621;
+  background: rgba(245, 158, 11, 0.15);
+  color: #b45309;
 }
 
 .flow-stats {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1rem;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.25rem;
   padding: 1rem;
-  background: #f8fafc;
-  border-radius: 8px;
-}
-
-.stat {
-  text-align: center;
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.75);
 }
 
 .stat-label {
   display: block;
-  font-size: 0.8rem;
-  color: #666;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
   margin-bottom: 0.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .stat-value {
-  font-weight: 600;
-  color: #2d3748;
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 1rem;
 }
 
 .flow-actions {
   display: flex;
-  gap: 0.5rem;
   flex-wrap: wrap;
+  gap: 0.6rem;
 }
 
-.edit-button, .toggle-button, .delete-button {
-  padding: 0.5rem 1rem;
+.edit-button,
+.toggle-button,
+.delete-button {
+  padding: 0.55rem 1.1rem;
   border: none;
-  border-radius: 6px;
+  border-radius: 0.75rem;
   font-size: 0.85rem;
+  font-weight: 600;
   cursor: pointer;
-  transition: all 0.3s ease;
+  color: #ffffff;
+  transition: transform 0.3s ease, opacity 0.3s ease;
 }
 
 .edit-button {
-  background: #667eea;
-  color: white;
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
 }
 
 .toggle-button.activate {
-  background: #48bb78;
-  color: white;
+  background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
 }
 
 .toggle-button.deactivate {
-  background: #ed8936;
-  color: white;
+  background: linear-gradient(135deg, #f97316 0%, #ea580c 100%);
 }
 
 .delete-button {
-  background: #e53e3e;
-  color: white;
+  background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
 }
 
-.edit-button:hover, .toggle-button:hover, .delete-button:hover {
-  transform: translateY(-1px);
+.edit-button:hover,
+.toggle-button:hover,
+.delete-button:hover {
+  transform: translateY(-2px);
   opacity: 0.9;
+}
+
+.create-first-flow-button {
+  margin-top: 1.5rem;
+  padding: 1rem 2rem;
+  border-radius: 0.9rem;
+  border: none;
+  background: linear-gradient(135deg, var(--primary-dark) 0%, var(--primary) 100%);
+  color: #ffffff;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 18px 35px rgba(7, 94, 84, 0.3);
+  transition: transform 0.3s ease;
+}
+
+.create-first-flow-button:hover {
+  transform: translateY(-2px);
+}
+
+@media (min-width: 1024px) {
+  .view-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .view-grid .whatsapp-card {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 768px) {
+  .app-surface {
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  .card {
+    padding: 1.5rem;
+  }
+
+  .card-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .app-hero h1 {
+    font-size: 2.25rem;
+  }
+
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* Flow Editor */
@@ -1935,13 +2050,6 @@ body {
 }
 
 /* WhatsApp Instances */
-.whatsapp-instances {
-  background: white;
-  border-radius: 16px;
-  padding: 2rem;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-}
-
 .instances-header {
   display: flex;
   justify-content: space-between;
@@ -1950,25 +2058,27 @@ body {
 }
 
 .instances-header h2 {
-  color: #2d3748;
-  font-size: 1.8rem;
+  color: var(--text-primary);
+  font-size: 1.6rem;
 }
 
-.create-instance-btn, .create-first-btn {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
+.create-instance-btn,
+.create-first-btn {
+  background: linear-gradient(135deg, var(--primary-dark) 0%, var(--primary) 100%);
+  color: #ffffff;
   border: none;
-  padding: 12px 24px;
-  border-radius: 8px;
-  font-size: 1rem;
-  font-weight: 500;
+  padding: 0.85rem 1.6rem;
+  border-radius: 0.85rem;
+  font-size: 0.95rem;
+  font-weight: 600;
   cursor: pointer;
-  transition: all 0.3s ease;
+  box-shadow: 0 18px 32px rgba(7, 94, 84, 0.25);
+  transition: transform 0.3s ease;
 }
 
-.create-instance-btn:hover, .create-first-btn:hover {
+.create-instance-btn:hover,
+.create-first-btn:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
 }
 
 .instances-grid {
@@ -1978,16 +2088,16 @@ body {
 }
 
 .instance-card {
-  border: 1px solid #e2e8f0;
-  border-radius: 12px;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
   padding: 1.5rem;
   transition: all 0.3s ease;
-  background: white;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95) 0%, rgba(230, 247, 242, 0.9) 100%);
 }
 
 .instance-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-soft);
 }
 
 .instance-header {
@@ -1998,14 +2108,14 @@ body {
 }
 
 .instance-info h3 {
-  color: #2d3748;
+  color: var(--text-primary);
   margin-bottom: 0.5rem;
   font-size: 1.2rem;
 }
 
 .instance-id {
   font-size: 0.8rem;
-  color: #666;
+  color: var(--text-secondary);
   font-family: 'Courier New', monospace;
 }
 
@@ -2013,24 +2123,24 @@ body {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.5rem 1rem;
-  border-radius: 25px;
-  font-weight: 500;
-  font-size: 0.85rem;
+  padding: 0.45rem 0.95rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.8rem;
 }
 
 .instance-status.connected {
-  background: #f0fff4;
-  color: #22543d;
+  background: rgba(37, 211, 102, 0.15);
+  color: var(--primary-dark);
 }
 
 .instance-status.connected .status-dot {
-  background: #48bb78;
+  background: var(--primary-light);
 }
 
 .instance-status.disconnected {
-  background: #fffaf0;
-  color: #c05621;
+  background: rgba(245, 158, 11, 0.18);
+  color: #b45309;
 }
 
 .instance-status.disconnected .status-dot {
@@ -2042,17 +2152,17 @@ body {
   align-items: center;
   gap: 1rem;
   padding: 1rem;
-  background: #f8fafc;
-  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 0.85rem;
   margin-bottom: 1rem;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--border);
 }
 
 .user-avatar {
   width: 40px;
   height: 40px;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-light) 100%);
+  color: #ffffff;
   border-radius: 50%;
   display: flex;
   align-items: center;
@@ -2067,13 +2177,13 @@ body {
 
 .user-name {
   font-weight: 600;
-  color: #2d3748;
+  color: var(--text-primary);
   margin-bottom: 0.25rem;
 }
 
 .user-phone {
   font-size: 0.85rem;
-  color: #666;
+  color: var(--text-secondary);
   font-family: 'Courier New', monospace;
 }
 
@@ -2083,8 +2193,8 @@ body {
   gap: 1rem;
   margin-bottom: 1.5rem;
   padding: 1rem;
-  background: #f8fafc;
-  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 0.85rem;
 }
 
 .instance-stats .stat {
@@ -2092,8 +2202,8 @@ body {
 }
 
 .instance-stats .stat-value {
-  font-weight: 600;
-  color: #2d3748;
+  font-weight: 700;
+  color: var(--text-primary);
   font-size: 1.5rem;
   display: block;
   margin-bottom: 0.25rem;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -28,54 +28,30 @@ const QRCode = ({ value }) => {
   );
 };
 
+const NAV_ITEMS = [
+  { id: 'dashboard', icon: '📊', label: 'Dashboard' },
+  { id: 'flows', icon: '🎯', label: 'Fluxos' },
+  { id: 'contacts', icon: '👥', label: 'Contatos' },
+  { id: 'messages', icon: '💬', label: 'Mensagens' },
+  { id: 'instances', icon: '📱', label: 'Instâncias' },
+  { id: 'settings', icon: '⚙️', label: 'Configurações' }
+];
+
 // Navigation Component
 const Navigation = ({ currentView, onViewChange }) => {
   return (
-    <nav className="main-navigation">
-      <div className="nav-items">
-        <button 
-          className={`nav-item ${currentView === 'dashboard' ? 'active' : ''}`}
-          onClick={() => onViewChange('dashboard')}
-        >
-          <span className="nav-icon">📊</span>
-          <span>Dashboard</span>
-        </button>
-        <button 
-          className={`nav-item ${currentView === 'flows' ? 'active' : ''}`}
-          onClick={() => onViewChange('flows')}
-        >
-          <span className="nav-icon">🎯</span>
-          <span>Fluxos</span>
-        </button>
-        <button 
-          className={`nav-item ${currentView === 'contacts' ? 'active' : ''}`}
-          onClick={() => onViewChange('contacts')}
-        >
-          <span className="nav-icon">👥</span>
-          <span>Contatos</span>
-        </button>
-        <button 
-          className={`nav-item ${currentView === 'messages' ? 'active' : ''}`}
-          onClick={() => onViewChange('messages')}
-        >
-          <span className="nav-icon">💬</span>
-          <span>Mensagens</span>
-        </button>
+    <nav className="app-nav">
+      {NAV_ITEMS.map((item) => (
         <button
-          className={`nav-item ${currentView === 'instances' ? 'active' : ''}`}
-          onClick={() => onViewChange('instances')}
+          key={item.id}
+          type="button"
+          className={`nav-button ${currentView === item.id ? 'active' : ''}`}
+          onClick={() => onViewChange(item.id)}
         >
-          <span className="nav-icon">📱</span>
-          <span>Instâncias</span>
+          <span className="nav-button-icon">{item.icon}</span>
+          <span className="nav-button-label">{item.label}</span>
         </button>
-        <button
-          className={`nav-item ${currentView === 'settings' ? 'active' : ''}`}
-          onClick={() => onViewChange('settings')}
-        >
-          <span className="nav-icon">⚙️</span>
-          <span>Configurações</span>
-        </button>
-      </div>
+      ))}
     </nav>
   );
 };
@@ -156,17 +132,26 @@ const WhatsAppConnection = () => {
     setLoading(false);
   };
 
+  const statusLabel =
+    status === 'connected'
+      ? 'Conectado'
+      : status === 'disconnected'
+        ? 'Desconectado'
+        : 'Erro';
+
   return (
-    <div className="whatsapp-connection">
-      <div className="connection-header">
-        <h2>🔗 Conexão WhatsApp</h2>
+    <div className="card whatsapp-card">
+      <div className="card-header">
+        <div>
+          <h2>🔗 Conexão WhatsApp</h2>
+          <p className="card-subtitle">
+            Monitore suas instâncias em tempo real e mantenha a automação ativa.
+          </p>
+        </div>
         <div className={`status-indicator ${status}`}>
-          <div className="status-dot"></div>
-          <span className="status-text">
-            {status === 'connected' ? 'Conectado' : 
-             status === 'disconnected' ? 'Desconectado' : 'Erro'}
-            {isDemoMode && ' (Demo)'}
-          </span>
+          <div className="status-dot" />
+          <span className="status-text">{statusLabel}</span>
+          {isDemoMode && <span className="status-tag">Demo</span>}
         </div>
       </div>
 
@@ -177,10 +162,8 @@ const WhatsAppConnection = () => {
       )}
 
       {status === 'connected' && connectedUser && (
-        <div className="connected-info">
-          <div className="success-badge">
-            ✅ WhatsApp conectado com sucesso!
-          </div>
+        <div className="connection-success">
+          <div className="success-badge">✅ WhatsApp conectado com sucesso!</div>
           <div className="user-info">
             <strong>Usuário:</strong> {connectedUser.name || connectedUser.id}
           </div>
@@ -188,11 +171,11 @@ const WhatsAppConnection = () => {
       )}
 
       {status === 'disconnected' && (
-        <div className="qr-section">
+        <div className="connection-body">
           <div className="warning-badge">
             ⚠️ WhatsApp não está conectado. {isDemoMode ? 'Clique para simular conexão ou ' : ''}Escaneie o QR code para conectar.
           </div>
-          
+
           {qrCode && (
             <div className="qr-display">
               <h3>Escaneie este QR Code com o WhatsApp:</h3>
@@ -202,21 +185,23 @@ const WhatsAppConnection = () => {
               </p>
             </div>
           )}
-          
+
           <div className="button-group">
-            <button 
+            <button
               className="connect-button"
               onClick={handleConnect}
               disabled={loading}
+              type="button"
             >
               {loading ? 'Conectando...' : 'Conectar WhatsApp'}
             </button>
-            
+
             {isDemoMode && (
-              <button 
+              <button
                 className="demo-button"
                 onClick={simulateConnection}
                 disabled={loading}
+                type="button"
               >
                 🎯 Simular Conexão (Demo)
               </button>
@@ -257,9 +242,11 @@ const DashboardStats = () => {
 
     return () => clearInterval(interval);
   }, []);
-
   return (
-    <div className="dashboard-stats">
+    <div className="card stats-card">
+      <div className="card-header">
+        <h2>📊 Estatísticas do Sistema</h2>
+      </div>
       <div className="stats-grid">
         <div className="stat-card">
           <div className="stat-icon">👥</div>
@@ -268,7 +255,7 @@ const DashboardStats = () => {
             <p>Novos contatos hoje</p>
           </div>
         </div>
-        
+
         <div className="stat-card">
           <div className="stat-icon">💬</div>
           <div className="stat-content">
@@ -276,7 +263,7 @@ const DashboardStats = () => {
             <p>Conversas ativas</p>
           </div>
         </div>
-        
+
         <div className="stat-card">
           <div className="stat-icon">📨</div>
           <div className="stat-content">
@@ -290,7 +277,10 @@ const DashboardStats = () => {
 };
 
 // Contacts List Component
-const ContactsList = () => {
+const ContactsList = ({
+  title = '📞 Contatos Recentes',
+  description = 'Os contatos aparecerão aqui assim que começarem a enviar mensagens.'
+}) => {
   const [contacts, setContacts] = useState([]);
   const [loading, setLoading] = useState(true);
 
@@ -308,14 +298,23 @@ const ContactsList = () => {
 
     fetchContacts();
   }, []);
-
   if (loading) {
-    return <div className="loading">Carregando contatos...</div>;
+    return (
+      <div className="card contacts-card">
+        <div className="loading">Carregando contatos...</div>
+      </div>
+    );
   }
 
   return (
-    <div className="contacts-list">
-      <h3>📞 Contatos Recentes</h3>
+    <div className="card contacts-card">
+      <div className="card-header">
+        <div>
+          <h3>{title}</h3>
+          <p className="card-subtitle">{description}</p>
+        </div>
+      </div>
+
       {contacts.length === 0 ? (
         <div className="empty-state">
           <p>Nenhum contato encontrado ainda.</p>
@@ -323,7 +322,7 @@ const ContactsList = () => {
         </div>
       ) : (
         <div className="contacts-grid">
-          {contacts.slice(0, 6).map(contact => (
+          {contacts.slice(0, 6).map((contact) => (
             <div key={contact.id} className="contact-card">
               <div className="contact-avatar">
                 {contact.name.charAt(0).toUpperCase()}
@@ -332,7 +331,7 @@ const ContactsList = () => {
                 <h4>{contact.name}</h4>
                 <p>{contact.phone_number}</p>
                 <div className="contact-tags">
-                  {contact.tags.map(tag => (
+                  {contact.tags.map((tag) => (
                     <span key={tag} className="tag">{tag}</span>
                   ))}
                 </div>
@@ -398,60 +397,66 @@ function App() {
   }
 
   return (
-    <div className="app">
-      <header className="app-header">
-        <div className="header-content">
-          <h1>🤖 WhatsFlow</h1>
-          <p>Sistema de Automação para WhatsApp</p>
-        </div>
-      </header>
+    <div className="app professional-app">
+      <div className="app-surface">
+        <div className="app-container">
+          <header className="app-hero">
+            <h1>🚀 WhatsFlow Professional</h1>
+            <p>Sistema avançado de automação WhatsApp com tempo real e múltiplas instâncias.</p>
+            <div className="hero-badge">
+              ✅ Conexão estável • Webhooks • Fluxos inteligentes
+            </div>
+          </header>
 
-      <Navigation currentView={currentView} onViewChange={setCurrentView} />
+          <Navigation currentView={currentView} onViewChange={setCurrentView} />
 
-      <main className="app-main">
-        <div className="container">
-          {currentView === 'dashboard' && (
-            <>
-              <WhatsAppConnection />
-              
-              <section className="dashboard-section">
-                <h2>📊 Dashboard</h2>
+          <main className="app-content">
+            {currentView === 'dashboard' && (
+              <div className="view-grid">
+                <WhatsAppConnection />
                 <DashboardStats />
-              </section>
-
-              <section className="contacts-section">
                 <ContactsList />
+              </div>
+            )}
+
+            {currentView === 'flows' && (
+              <section className="view-section">
+                <FlowList
+                  onCreateFlow={handleCreateFlow}
+                  onEditFlow={handleEditFlow}
+                />
               </section>
-            </>
-          )}
+            )}
 
-          {currentView === 'flows' && (
-            <FlowList
-              onCreateFlow={handleCreateFlow}
-              onEditFlow={handleEditFlow}
-            />
-          )}
+            {currentView === 'contacts' && (
+              <section className="view-section">
+                <ContactsList
+                  title="👥 Gerenciamento de Contatos"
+                  description="Acompanhe seus contatos sincronizados e etiquetas aplicadas."
+                />
+              </section>
+            )}
 
-          {currentView === 'contacts' && (
-            <section className="contacts-section">
-              <h2>👥 Gerenciamento de Contatos</h2>
-              <ContactsList />
-            </section>
-          )}
+            {currentView === 'messages' && (
+              <section className="view-section">
+                <MessagesCenter baileysHealthy={baileysHealthy} />
+              </section>
+            )}
 
-          {currentView === 'messages' && (
-            <MessagesCenter baileysHealthy={baileysHealthy} />
-          )}
+            {currentView === 'instances' && (
+              <section className="view-section">
+                <WhatsAppInstances />
+              </section>
+            )}
 
-          {currentView === 'instances' && (
-            <WhatsAppInstances />
-          )}
-
-          {currentView === 'settings' && (
-            <Settings />
-          )}
+            {currentView === 'settings' && (
+              <section className="view-section">
+                <Settings />
+              </section>
+            )}
+          </main>
         </div>
-      </main>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/FlowList.js
+++ b/frontend/src/components/FlowList.js
@@ -68,11 +68,15 @@ export default function FlowList({ onCreateFlow, onEditFlow }) {
   };
 
   if (loading) {
-    return <div className="loading">Carregando fluxos...</div>;
+    return (
+      <div className="card flow-list">
+        <div className="loading">Carregando fluxos...</div>
+      </div>
+    );
   }
 
   return (
-    <div className="flow-list">
+    <div className="card flow-list">
       <div className="flow-list-header">
         <h2>🎯 Fluxos de Automação</h2>
         <button onClick={onCreateFlow} className="create-flow-button">

--- a/frontend/src/components/Settings.js
+++ b/frontend/src/components/Settings.js
@@ -107,7 +107,7 @@ const Settings = () => {
   };
 
   return (
-    <div className="settings">
+    <div className="card settings">
       <h2>⚙️ Configurações</h2>
       <div className="settings-tabs">
         <div

--- a/frontend/src/components/WhatsAppInstances.js
+++ b/frontend/src/components/WhatsAppInstances.js
@@ -143,11 +143,15 @@ export default function WhatsAppInstances() {
   };
 
   if (loading) {
-    return <div className="loading">Carregando instâncias WhatsApp...</div>;
+    return (
+      <div className="card whatsapp-instances">
+        <div className="loading">Carregando instâncias WhatsApp...</div>
+      </div>
+    );
   }
 
   return (
-    <div className="whatsapp-instances">
+    <div className="card whatsapp-instances">
       <div className="instances-header">
         <h2>📱 Instâncias WhatsApp</h2>
         <button 


### PR DESCRIPTION
## Summary
- rebuild the main WhatsFlow shell with a professional hero, navigation bar, and card-based sections
- restyle global components with a new palette, gradients, and reusable card utilities across dashboard, contacts, and instances
- wrap flows, settings, and instance management in card layouts to match the refreshed UI

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68c9779dd538832fad1a05857d820552