### PR TITLE
Normalize MinIO public URLs to https by default

### DIFF
--- a/tests/test_minio_public_url.py
+++ b/tests/test_minio_public_url.py
@@ -1,0 +1,153 @@
+import datetime
+import importlib.util
+import sqlite3
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "whatsflow-real.py"
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, text="OK"):
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return {}
+
+
+@pytest.fixture
+def whatsflow_module(monkeypatch, tmp_path):
+    # Provide a lightweight "requests" module so importing whatsflow-real doesn't
+    # attempt external HTTP calls or install dependencies.
+    class FakeRequestException(Exception):
+        pass
+
+    class FakeTimeout(FakeRequestException):
+        pass
+
+    def fake_get(url, timeout=0, *args, **kwargs):
+        if "api.ipify.org" in url:
+            return FakeResponse(status_code=200, text="198.51.100.1")
+        return FakeResponse(status_code=200, text="OK")
+
+    fake_requests = types.ModuleType("requests")
+    fake_requests.get = fake_get
+    fake_requests.post = lambda *args, **kwargs: FakeResponse()
+    fake_requests.RequestException = FakeRequestException
+    fake_requests.exceptions = types.SimpleNamespace(
+        Timeout=FakeTimeout, RequestException=FakeRequestException
+    )
+
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+
+    # Provide a tiny pytz replacement for modules that expect it during import.
+    class _FakeTimezone(datetime.tzinfo):
+        def __init__(self, name: str):
+            self._name = name
+
+        def utcoffset(self, dt):
+            return datetime.timedelta(0)
+
+        def dst(self, dt):
+            return datetime.timedelta(0)
+
+        def tzname(self, dt):
+            return self._name
+
+    fake_pytz = types.ModuleType("pytz")
+
+    def fake_timezone(name: str):
+        return _FakeTimezone(name)
+
+    fake_pytz.timezone = fake_timezone
+    monkeypatch.setitem(sys.modules, "pytz", fake_pytz)
+
+    # Route database access to a temporary location to avoid mutating repo files.
+    original_connect = sqlite3.connect
+    temp_db = tmp_path / "minio-test.db"
+
+    def connect_override(path, *args, **kwargs):
+        if path == "whatsflow.db":
+            path = temp_db
+        return original_connect(path, *args, **kwargs)
+
+    monkeypatch.setattr(sqlite3, "connect", connect_override)
+
+    env = {
+        "MINIO_ACCESS_KEY": "test-access",
+        "MINIO_SECRET_KEY": "test-secret",
+        "MINIO_BUCKET": "test-bucket",
+        "MINIO_ENDPOINT": "http://minio.internal:9000",
+        "MINIO_PUBLIC_URL": "media.example.com",
+    }
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    module_name = "whatsflow_real_test_instance"
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    loader = spec.loader
+    assert loader is not None
+    loader.exec_module(module)
+
+    module.DB_FILE = str(temp_db)
+    module.reload_minio_settings_from_db()
+    return module
+
+
+def test_schemeless_public_host_defaults_to_https(monkeypatch, whatsflow_module):
+    module = whatsflow_module
+
+    assert module.MINIO_PUBLIC_URL == "https://media.example.com"
+
+    object_url = module._build_minio_object_url(None, "path/file.png")
+    assert object_url == "https://media.example.com/test-bucket/path/file.png"
+
+    captured = {}
+
+    monkeypatch.setattr(module, "check_service_health", lambda _: True)
+
+    class SendResponse:
+        status_code = 200
+        text = "OK"
+
+    def fake_post(url, json=None, timeout=None, *args, **kwargs):
+        captured["url"] = url
+        captured["payload"] = json
+        captured["timeout"] = timeout
+        return SendResponse()
+
+    monkeypatch.setattr(module.requests, "post", fake_post)
+
+    scheduler = module.MessageScheduler("http://baileys.test")
+    success, error = scheduler._send_message_to_group(
+        "instance-1", "group-1", "hello", "image", object_url
+    )
+
+    assert success is True
+    assert error is None
+    assert captured["payload"]["mediaUrl"] == object_url
+    assert captured["payload"]["type"] == "image"
+
+    monkeypatch.delenv("MINIO_PUBLIC_URL", raising=False)
+    module.save_minio_credentials(
+        "persist-access",
+        "persist-secret",
+        module.MINIO_BUCKET,
+        "assets.example.com",
+    )
+
+    with sqlite3.connect(module.DB_FILE) as conn:
+        row = conn.execute(
+            "SELECT url FROM minio_credentials ORDER BY ROWID DESC LIMIT 1"
+        ).fetchone()
+
+    assert row[0] == "https://assets.example.com"
+    assert module.MINIO_PUBLIC_URL == "https://assets.example.com"

--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -29,6 +29,7 @@ import pytz
 import io
 import importlib
 import cgi
+import ipaddress
 
 warnings.filterwarnings("ignore", category=DeprecationWarning, module="cgi")
 
@@ -150,6 +151,51 @@ def _parse_minio_endpoint(endpoint: str) -> Tuple[str, bool]:
     return cleaned, secure
 
 
+_LOCAL_PUBLIC_HOST_SUFFIXES = (".local", ".localhost", ".lan", ".internal", ".home")
+_LOCAL_PUBLIC_HOSTNAMES = {
+    "localhost",
+    "host.docker.internal",
+}
+_TRUE_LIKE = {"1", "true", "yes", "on"}
+_FALSE_LIKE = {"0", "false", "no", "off"}
+
+
+def _parse_optional_bool(value: Optional[str]) -> Optional[bool]:
+    if value is None:
+        return None
+    cleaned = value.strip().lower()
+    if not cleaned:
+        return None
+    if cleaned in _TRUE_LIKE:
+        return True
+    if cleaned in _FALSE_LIKE:
+        return False
+    return None
+
+
+def _extract_hostname(authority: str) -> str:
+    host = authority.split("/", 1)[0]
+    if host.startswith("[") and "]" in host:
+        return host[1 : host.index("]")]
+    if ":" in host:
+        return host.split(":", 1)[0]
+    return host
+
+
+def _is_local_public_hostname(hostname: str) -> bool:
+    host_lower = hostname.lower()
+    if host_lower in _LOCAL_PUBLIC_HOSTNAMES:
+        return True
+    for suffix in _LOCAL_PUBLIC_HOST_SUFFIXES:
+        if host_lower.endswith(suffix):
+            return True
+    try:
+        ip_obj = ipaddress.ip_address(host_lower)
+        return ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_link_local
+    except ValueError:
+        return False
+
+
 def _normalize_minio_public_url_value(
     url: Optional[str], *, secure_default: Optional[bool] = None
 ) -> Optional[str]:
@@ -162,9 +208,15 @@ def _normalize_minio_public_url_value(
 
     normalized = trimmed.rstrip("/")
     if "://" not in normalized:
-        if secure_default is None:
-            secure_default = _MINIO_SECURE_DEFAULT
-        scheme = "https" if secure_default else "http"
+        override = secure_default
+        if override is None:
+            override = _parse_optional_bool(os.environ.get("MINIO_PUBLIC_URL_SECURE"))
+        hostname = _extract_hostname(normalized)
+        scheme = "https"
+        if override is not None:
+            scheme = "https" if override else "http"
+        elif hostname and _is_local_public_hostname(hostname):
+            scheme = "http"
         normalized = f"{scheme}://{normalized}"
 
     return normalized
@@ -190,8 +242,7 @@ def _load_minio_configuration() -> Tuple[str, str, str, str, Optional[str]]:
         if not public_url:
             public_url = stored_url or public_url
 
-    _, secure_default = _parse_minio_endpoint(endpoint_raw)
-    public_url = _normalize_minio_public_url_value(public_url, secure_default=secure_default)
+    public_url = _normalize_minio_public_url_value(public_url)
 
     return endpoint_raw, access_key, secret_key, bucket, public_url
 


### PR DESCRIPTION
## Summary
- Default schemeless MinIO public URLs to https unless a local hostname or MINIO_PUBLIC_URL_SECURE override requires http, and tighten normalization helpers.
- Ensure MinIO configuration reloads reuse the updated normalization logic so saved values retain the corrected scheme.
- Add a regression test that stubs external dependencies, verifies https is used in generated media URLs, and confirms saved credentials persist the normalized value.

## Testing
- `python -m pytest tests/test_minio_public_url.py`


------
https://chatgpt.com/codex/tasks/task_e_68cad8867f50832f9d0af0fbb9f9763d