### PR TITLE
Default schemeless MinIO public URLs to HTTPS

### DIFF
--- a/tests/test_minio_public_url.py
+++ b/tests/test_minio_public_url.py
@@ -1,0 +1,73 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+import requests
+import sqlite3
+
+
+def _load_whatsflow_module(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    db_path = tmp_path / "test_whatsflow.db"
+    real_connect = sqlite3.connect
+
+    def patched_connect(*args, **kwargs):
+        if args:
+            args = (str(db_path),) + args[1:]
+        elif "database" in kwargs:
+            kwargs["database"] = str(db_path)
+        else:
+            args = (str(db_path),)
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(sqlite3, "connect", patched_connect)
+
+    module_name = "whatsflow_real_for_tests"
+    module_path = Path(__file__).resolve().parent.parent / "whatsflow-real.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_schemeless_public_url_defaults_to_https(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    def fake_get(url, *args, **kwargs):
+        if "api.ipify.org" in url:
+            return SimpleNamespace(status_code=200, text="203.0.113.10")
+        return SimpleNamespace(status_code=200, text="ok")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    monkeypatch.setenv("MINIO_ENDPOINT", "http://minio.internal:9000")
+    monkeypatch.setenv("MINIO_PUBLIC_URL", "cdn.example.com")
+
+    module = _load_whatsflow_module(monkeypatch, tmp_path)
+
+    assert module._MINIO_SECURE_DEFAULT is False
+    assert module.MINIO_PUBLIC_URL == "https://cdn.example.com"
+
+    media_url = module._build_minio_object_url(object(), "file.png")
+    assert media_url == "https://cdn.example.com/meu-bucket/file.png"
+
+    scheduler = module.MessageScheduler("https://baileys.internal")
+
+    with mock.patch.object(module, "check_service_health", return_value=True), mock.patch.object(
+        module.requests, "post"
+    ) as mock_post:
+        mock_post.return_value = SimpleNamespace(status_code=200, text="ok")
+        success, error = scheduler._send_message_to_group(
+            "instance-123",
+            "123@g.us",
+            "Caption",
+            "image",
+            media_url,
+        )
+
+    assert success is True
+    assert error is None
+
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["mediaUrl"] == media_url
+    assert payload["mediaUrl"].startswith("https://")

--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -150,6 +150,27 @@ def _parse_minio_endpoint(endpoint: str) -> Tuple[str, bool]:
     return cleaned, secure
 
 
+def _is_localhost_like(hostname: Optional[str]) -> bool:
+    if not hostname:
+        return False
+
+    cleaned = hostname.strip().lower()
+    if not cleaned:
+        return False
+
+    if cleaned.startswith("[") and cleaned.endswith("]"):
+        cleaned = cleaned[1:-1]
+
+    if cleaned.startswith("localhost"):
+        return True
+    if cleaned.startswith("127."):
+        return True
+    if cleaned in {"0.0.0.0", "::1"}:
+        return True
+
+    return False
+
+
 def _normalize_minio_public_url_value(
     url: Optional[str], *, secure_default: Optional[bool] = None
 ) -> Optional[str]:
@@ -162,8 +183,10 @@ def _normalize_minio_public_url_value(
 
     normalized = trimmed.rstrip("/")
     if "://" not in normalized:
+        parsed = urllib.parse.urlparse(f"//{normalized}")
+        hostname = parsed.hostname or normalized.split(":", 1)[0]
         if secure_default is None:
-            secure_default = _MINIO_SECURE_DEFAULT
+            secure_default = not _is_localhost_like(hostname)
         scheme = "https" if secure_default else "http"
         normalized = f"{scheme}://{normalized}"
 
@@ -190,8 +213,7 @@ def _load_minio_configuration() -> Tuple[str, str, str, str, Optional[str]]:
         if not public_url:
             public_url = stored_url or public_url
 
-    _, secure_default = _parse_minio_endpoint(endpoint_raw)
-    public_url = _normalize_minio_public_url_value(public_url, secure_default=secure_default)
+    public_url = _normalize_minio_public_url_value(public_url)
 
     return endpoint_raw, access_key, secret_key, bucket, public_url
 


### PR DESCRIPTION
## Summary
- default schemeless MinIO public URLs to HTTPS while keeping localhost-style hosts on HTTP when appropriate
- ensure MinIO public URL normalization no longer inherits the endpoint's insecure default
- add regression coverage verifying Baileys payloads use HTTPS when the public CDN host is schemeless

## Testing
- pytest tests/test_minio_public_url.py

------
https://chatgpt.com/codex/tasks/task_e_68cae9c0bd5c832f9c2971e48a5bd9ae