### PR TITLE
Fix media scheduling validation and error handling

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -6959,8 +6959,8 @@ HTML_APP = '''<!DOCTYPE html>
                 }
                 
                 // Create scheduled message for each group
-                const promises = groupsToUse.map(group => {
-                    return fetch(`${WHATSFLOW_API_URL}/api/scheduled-messages`, {
+                const promises = groupsToUse.map(async group => {
+                    const response = await fetch(`${WHATSFLOW_API_URL}/api/scheduled-messages`, {
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json'
@@ -6979,10 +6979,23 @@ HTML_APP = '''<!DOCTYPE html>
                             schedule_days: scheduleDays
                         })
                     });
+                    if (!response.ok) {
+                        let errorMessage = `Erro ao agendar mensagem para ${group.group_name}`;
+                        try {
+                            const errorData = await response.json();
+                            if (errorData && errorData.error) {
+                                errorMessage = errorData.error;
+                            }
+                        } catch (err) {
+                            // Ignore JSON parse errors and use default message
+                        }
+                        throw new Error(errorMessage);
+                    }
+                    return response.json();
                 });
-                
+
                 await Promise.all(promises);
-                
+
                 alert(`✅ Mensagem agendada para ${groupsToUse.length} grupo(s)!`);
                 hideScheduleMessageModal();
                 
@@ -8796,9 +8809,9 @@ class MessageScheduler:
             for row in messages_to_send:
                 try:
                     message_id = row[0]
-                    message_text = row[2]
-                    message_type = row[3]
-                    media_url = row[4]
+                    message_text = row[2] or ''
+                    message_type = (row[3] or 'text').lower()
+                    media_url = (row[4] or '').strip()
                     schedule_type = row[5]
                     schedule_time = row[6]
                     schedule_days = row[7]
@@ -8899,20 +8912,20 @@ class MessageScheduler:
                 print(f"❌ {error_msg}")
                 return False, error_msg
 
-            if message_type == 'text':
-                payload = {
-                    'to': group_id,
-                    'type': 'text',
-                    'message': message_text or ''
-                }
-            else:
-                payload = {
-                    'to': group_id,
-                    'type': message_type,
-                    'mediaUrl': media_url,
-                }
-                if message_text:
-                    payload['message'] = message_text
+            payload = {
+                'to': group_id,
+                'type': 'text',
+                'message': message_text or ''
+            }
+
+            if message_type != 'text':
+                if not media_url:
+                    error_msg = 'URL de mídia não definida para mensagem de mídia agendada'
+                    logger.error(error_msg)
+                    return False, error_msg
+
+                payload['type'] = message_type
+                payload['mediaUrl'] = media_url
 
             for attempt in range(3):
                 try:
@@ -8932,10 +8945,17 @@ class MessageScheduler:
                     )
                     
                     if response.status_code != 200:
+                        try:
+                            error_payload = response.json()
+                            error_detail = error_payload.get('error')
+                        except Exception:
+                            error_detail = response.text
+
                         logger.error(
-                            f"Baileys send failed ({response.status_code}): {response.text}"
+                            f"Baileys send failed ({response.status_code}): {error_detail}"
                         )
-                        return False, f"Baileys send failed ({response.status_code})"
+                        detail_message = error_detail or f"HTTP {response.status_code}"
+                        return False, f"Baileys send failed ({response.status_code}): {detail_message}"
 
                     return True, None
                 except requests.exceptions.Timeout:
@@ -10967,18 +10987,34 @@ class WhatsFlowRealHandler(BaseHTTPRequestHandler):
 
             # Optional campaign field
             campaign_id = data.get('campaign_id', None)
-            
+
             # Optional fields
-            message_text = data.get('message_text', '')
-            message_type = data.get('message_type', 'text')
-            media_url = data.get('media_url', '')
+            message_text = (data.get('message_text') or '').strip()
+            raw_message_type = (data.get('message_type') or data.get('messageType') or 'text')
+            message_type = raw_message_type.strip().lower()
+            media_url = (data.get('media_url') or data.get('mediaUrl') or '').strip()
             schedule_date = data.get('schedule_date')
             schedule_days = data.get('schedule_days', [])
-            
+
+            valid_message_types = {'text', 'image', 'audio', 'video', 'document'}
+            if message_type not in valid_message_types:
+                self.send_json_response({"error": "Tipo de mensagem inválido"}, 400)
+                return
+
             if not all([group_id, group_name, instance_id, schedule_type, schedule_time]):
                 self.send_json_response({"error": "Campos obrigatórios faltando"}, 400)
                 return
-            
+
+            if message_type != 'text':
+                if not media_url:
+                    self.send_json_response({"error": "URL de mídia é obrigatória para mensagens de mídia"}, 400)
+                    return
+
+                parsed = urllib.parse.urlparse(media_url)
+                if parsed.scheme not in ("http", "https") or not parsed.netloc:
+                    self.send_json_response({"error": "URL de mídia inválida"}, 400)
+                    return
+
             # Calculate next run using Brazil timezone
             from datetime import datetime, timedelta
             import pytz


### PR DESCRIPTION
## Summary
- validate scheduled message payloads to accept media types safely and reject missing or invalid media URLs
- harden scheduler payload generation to always include captions, guard against absent media links and surface Baileys errors
- surface scheduling API errors in the groups tab so media issues are shown to the operator instead of silently succeeding

## Testing
- python -m py_compile whatsflow-real.py

------
https://chatgpt.com/codex/tasks/task_e_68d1e169e164832fb20b0844b01030c6