### PR TITLE
Increase Baileys JSON body limit

### DIFF
--- a/baileys_service/server.js
+++ b/baileys_service/server.js
@@ -13,7 +13,7 @@ app.use(cors({
     methods: ['*'],
     allowedHeaders: ['*']
 }));
-app.use(express.json());
+app.use(express.json({ limit: '50mb' }));
 
 // Global state management
 let instances = new Map(); // instanceId -> { sock, qr, connected, connecting, user }


### PR DESCRIPTION
## Summary
- raise Express JSON body size limit to 50 MB to avoid PayloadTooLargeError when sending media messages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1f31dbf48832fa06c363ad31829d3