### PR TITLE
Increase Baileys body parser limit

### DIFF
--- a/baileys_service/server.js
+++ b/baileys_service/server.js
@@ -13,7 +13,11 @@ app.use(cors({
     methods: ['*'],
     allowedHeaders: ['*']
 }));
-app.use(express.json({ limit: '50mb' }));
+
+// Allow configuring body size to avoid 413 PayloadTooLargeError when sending media as base64
+const BODY_LIMIT = process.env.BAILEYS_BODY_LIMIT || '100mb';
+app.use(express.json({ limit: BODY_LIMIT }));
+app.use(express.urlencoded({ limit: BODY_LIMIT, extended: true }));
 
 // Global state management
 let instances = new Map(); // instanceId -> { sock, qr, connected, connecting, user }


### PR DESCRIPTION
## Summary
- allow configuring the Baileys Express body parser limit via environment variable
- raise default JSON and URL-encoded payload limits to 100MB to avoid PayloadTooLargeError

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1f4a88270832f8bcbd257a13fe5c6