### PR TITLE
Avoid downloading media payloads for scheduled messages

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -8,7 +8,6 @@ Instalação: python3 whatsflow-real.py
 Acesso: http://localhost:8888
 """
 
-import base64
 import json
 import sqlite3
 import uuid
@@ -8953,24 +8952,6 @@ class MessageScheduler:
         if normalized_type == 'document':
             file_name = os.path.basename(urllib.parse.urlparse(media_url).path) or 'documento'
             payload['fileName'] = file_name
-
-        if normalized_type == 'image':
-            http = _ensure_requests_dependency()
-            try:
-                download_response = http.get(media_url, timeout=(10, 45))
-                download_response.raise_for_status()
-            except Exception as exc:  # pragma: no cover - defensive logging
-                logger.warning(
-                    "Não foi possível baixar mídia %s para envio direto: %s. Usando URL remota.",
-                    media_url,
-                    exc,
-                )
-            else:
-                payload['imageData'] = base64.b64encode(download_response.content).decode('ascii')
-                logger.debug(
-                    "Mídia baixada com sucesso para envio direto (%s bytes)",
-                    len(download_response.content),
-                )
 
         return payload, None
 


### PR DESCRIPTION
## Summary
- stop downloading scheduled image media inside `_build_baileys_payload`, keeping only the remote media URL metadata
- update the Baileys send endpoint to always consume remote media URLs while retaining a legacy base64 fallback for images

## Testing
- python media_scheduling_test.py *(fails: local Baileys/WhatsFlow services not running in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2e954d544832f80c8a9cf8aa42c40