### PR TITLE
Handle oversized base64 payload errors

### DIFF
--- a/baileys_service/server.js
+++ b/baileys_service/server.js
@@ -20,6 +20,26 @@ const MAX_MEDIA_BYTES = 15 * 1024 * 1024;
 app.use(express.json({ limit: BODY_LIMIT }));
 app.use(express.urlencoded({ limit: BODY_LIMIT, extended: true }));
 
+app.use((err, req, res, next) => {
+    if (
+        err &&
+        (err.type === 'entity.too.large' ||
+            err.name === 'PayloadTooLargeError' ||
+            err.status === 413 ||
+            err.statusCode === 413)
+    ) {
+        console.warn(
+            '⚠️ Payload base64 recebido excede o limite suportado. Utilize URLs HTTP/HTTPS públicas para enviar mídias.',
+        );
+        return res.status(413).json({
+            error:
+                'Envio de mídia em base64 excede o limite suportado. Forneça mídias via URLs HTTP/HTTPS acessíveis publicamente.',
+        });
+    }
+
+    return next(err);
+});
+
 const BASE64_ALLOWED_CHARS = /^[A-Za-z0-9+/=\n\r\t ]+$/;
 const SUPPORTED_MEDIA_TYPES = new Set(['image', 'video', 'audio', 'document']);
 


### PR DESCRIPTION
## Summary
- add Express error handler to intercept PayloadTooLargeError from body parsing
- warn about oversized base64 payloads and instruct clients to use public media URLs
- fall back to existing error handling for other error types

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2f4ccf828832fb2ed8090425b66cb