### PR TITLE
Add Swagger documentation to Baileys service

### DIFF
--- a/baileys_service/package-lock.json
+++ b/baileys_service/package-lock.json
@@ -12,7 +12,53 @@
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "node-fetch": "^2.6.7",
-        "qrcode-terminal": "^0.12.0"
+        "qrcode-terminal": "^0.12.0",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^5.0.1"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
       }
     },
     "node_modules/@borewit/text-codec": {
@@ -505,6 +551,12 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
+    },
     "node_modules/@keyv/serialize": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
@@ -575,6 +627,13 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
@@ -620,6 +679,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "license": "MIT"
     },
     "node_modules/@types/long": {
@@ -688,6 +753,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -729,6 +800,12 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
@@ -751,6 +828,16 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/bytes": {
@@ -800,6 +887,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "license": "MIT"
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -857,6 +950,21 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -960,6 +1068,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1039,6 +1159,15 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -1200,6 +1329,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1244,6 +1379,27 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gopd": {
@@ -1351,6 +1507,17 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1372,6 +1539,18 @@
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/keyv": {
       "version": "5.5.1",
@@ -1429,6 +1608,26 @@
         "pbjs": "bin/pbjs",
         "pbts": "bin/pbts"
       }
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "license": "MIT"
     },
     "node_modules/long": {
       "version": "5.3.2",
@@ -1503,6 +1702,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -1635,6 +1846,22 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1642,6 +1869,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-to-regexp": {
@@ -2084,6 +2320,62 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.29.0.tgz",
+      "integrity": "sha512-gqs7Md3AxP4mbpXAq31o5QW+wGUZsUzVatg70yXpUR245dfIis5jAzufBd+UQM/w2xSfrhvA1eqsrgnl2PbezQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/thread-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
@@ -2200,6 +2492,15 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/validator": {
+      "version": "13.15.15",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
+      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -2225,6 +2526,12 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
@@ -2244,6 +2551,45 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     }
   }

--- a/baileys_service/package.json
+++ b/baileys_service/package.json
@@ -8,7 +8,9 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "node-fetch": "^2.6.7",
-    "qrcode-terminal": "^0.12.0"
+    "qrcode-terminal": "^0.12.0",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1"
   },
   "scripts": {
     "start": "node server.js"

--- a/baileys_service/server.js
+++ b/baileys_service/server.js
@@ -5,8 +5,11 @@ const makeWASocket = require('@whiskeysockets/baileys').default;
 const qrTerminal = require('qrcode-terminal');
 const fs = require('fs');
 const path = require('path');
+const swaggerUi = require('swagger-ui-express');
+const swaggerJsdoc = require('swagger-jsdoc');
 
 const app = express();
+const PORT = process.env.PORT || 3002;
 app.use(cors({
     origin: '*',
     credentials: true,
@@ -19,6 +22,367 @@ const BODY_LIMIT = '15mb';
 const MAX_MEDIA_BYTES = 15 * 1024 * 1024;
 app.use(express.json({ limit: BODY_LIMIT }));
 app.use(express.urlencoded({ limit: BODY_LIMIT, extended: true }));
+
+const swaggerDefinition = {
+    openapi: '3.0.0',
+    info: {
+        title: 'WhatsFlow Baileys Service API',
+        version: '1.0.0',
+        description:
+            'Documentação da API responsável por gerenciar sessões do WhatsApp via Baileys.',
+    },
+    servers: [
+        {
+            url: process.env.SWAGGER_SERVER_URL || `http://localhost:${PORT}`,
+            description: 'Servidor atual do serviço Baileys',
+        },
+    ],
+    components: {
+        parameters: {
+            InstanceIdParam: {
+                name: 'instanceId',
+                in: 'path',
+                required: true,
+                schema: { type: 'string' },
+                description: 'Identificador único da instância Baileys',
+            },
+        },
+        schemas: {
+            InstanceState: {
+                type: 'object',
+                properties: {
+                    connected: { type: 'boolean', description: 'Indica se a instância está conectada.' },
+                    connecting: {
+                        type: 'boolean',
+                        description: 'Indica se a instância está em processo de conexão.',
+                    },
+                    user: {
+                        type: ['object', 'null'],
+                        description: 'Informações do usuário autenticado na instância.',
+                        properties: {
+                            id: { type: 'string' },
+                            name: { type: 'string' },
+                            profilePictureUrl: { type: ['string', 'null'] },
+                            phone: { type: 'string' },
+                        },
+                    },
+                    instanceId: { type: 'string' },
+                    lastSeen: {
+                        type: ['string', 'null'],
+                        format: 'date-time',
+                        description: 'Última vez que a instância teve atividade registrada.',
+                    },
+                },
+            },
+            InstancesStatusResponse: {
+                type: 'object',
+                additionalProperties: { $ref: '#/components/schemas/InstanceState' },
+            },
+            QrResponse: {
+                type: 'object',
+                properties: {
+                    qr: { type: ['string', 'null'], description: 'Conteúdo do QR Code para autenticação.' },
+                    connected: { type: 'boolean' },
+                    instanceId: { type: 'string' },
+                    expiresIn: {
+                        type: 'integer',
+                        description: 'Tempo em segundos até o QR Code expirar.',
+                    },
+                },
+            },
+            ActionResponse: {
+                type: 'object',
+                properties: {
+                    success: { type: 'boolean' },
+                    message: { type: 'string' },
+                    instanceId: { type: 'string' },
+                },
+            },
+            SendRequest: {
+                type: 'object',
+                required: ['to'],
+                properties: {
+                    to: {
+                        type: 'string',
+                        description:
+                            'Número do destinatário no formato MSISDN (com DDI). O sufixo @s.whatsapp.net é adicionado automaticamente quando omitido.',
+                    },
+                    message: {
+                        type: 'string',
+                        description: 'Conteúdo textual da mensagem ou URL da mídia quando aplicável.',
+                    },
+                    type: {
+                        type: 'string',
+                        description:
+                            "Tipo de mensagem a ser enviada. Utilize 'text', 'image', 'video', 'audio', 'document' ou 'media'.",
+                        default: 'text',
+                    },
+                    caption: {
+                        type: 'string',
+                        description: 'Legenda opcional enviada junto com mídias suportadas.',
+                    },
+                    mediaUrl: {
+                        type: 'string',
+                        description:
+                            'URL pública da mídia quando o tipo não for genérico. Obrigatória para image, video, audio ou document.',
+                    },
+                    fileName: {
+                        type: 'string',
+                        description: 'Nome do arquivo quando o tipo document for utilizado.',
+                    },
+                    mediaType: {
+                        type: 'string',
+                        description:
+                            "Quando type='media', especifica o tipo real da mídia (image, video, audio ou document).",
+                    },
+                },
+            },
+            SendSuccessResponse: {
+                type: 'object',
+                properties: {
+                    success: { type: 'boolean' },
+                    instanceId: { type: 'string' },
+                },
+            },
+            ErrorResponse: {
+                type: 'object',
+                properties: {
+                    error: { type: 'string' },
+                    instanceId: { type: 'string' },
+                },
+            },
+            GroupInfo: {
+                type: 'object',
+                properties: {
+                    id: { type: 'string' },
+                    name: { type: 'string' },
+                    description: { type: 'string' },
+                    participants: { type: 'integer' },
+                    admin: { type: 'boolean' },
+                    created: { type: ['integer', 'null'] },
+                    lastMessage: {
+                        type: ['object', 'null'],
+                        properties: {
+                            text: { type: 'string' },
+                            timestamp: { type: ['integer', 'null'] },
+                        },
+                    },
+                },
+            },
+            GroupsResponse: {
+                type: 'object',
+                properties: {
+                    success: { type: 'boolean' },
+                    instanceId: { type: 'string' },
+                    count: { type: 'integer' },
+                    timestamp: { type: 'string', format: 'date-time' },
+                    groups: {
+                        type: 'array',
+                        items: { $ref: '#/components/schemas/GroupInfo' },
+                    },
+                    error: { type: 'string' },
+                },
+            },
+            HealthResponse: {
+                type: 'object',
+                properties: {
+                    status: { type: 'string' },
+                    instances: {
+                        type: 'object',
+                        properties: {
+                            total: { type: 'integer' },
+                            connected: { type: 'integer' },
+                            connecting: { type: 'integer' },
+                        },
+                    },
+                    uptime: { type: 'number' },
+                    timestamp: { type: 'string', format: 'date-time' },
+                },
+            },
+        },
+    },
+    paths: {
+        '/status': {
+            get: {
+                tags: ['Instâncias'],
+                summary: 'Lista o status de todas as instâncias ativas.',
+                responses: {
+                    200: {
+                        description: 'Status atual das instâncias monitoradas.',
+                        content: {
+                            'application/json': {
+                                schema: { $ref: '#/components/schemas/InstancesStatusResponse' },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        '/status/{instanceId}': {
+            get: {
+                tags: ['Instâncias'],
+                summary: 'Recupera o status de uma instância específica.',
+                parameters: [{ $ref: '#/components/parameters/InstanceIdParam' }],
+                responses: {
+                    200: {
+                        description: 'Status detalhado da instância informada.',
+                        content: {
+                            'application/json': {
+                                schema: { $ref: '#/components/schemas/InstanceState' },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        '/qr/{instanceId}': {
+            get: {
+                tags: ['Autenticação'],
+                summary: 'Obtém o QR Code atual de uma instância para autenticação.',
+                parameters: [{ $ref: '#/components/parameters/InstanceIdParam' }],
+                responses: {
+                    200: {
+                        description: 'Detalhes do QR Code vigente.',
+                        content: {
+                            'application/json': {
+                                schema: { $ref: '#/components/schemas/QrResponse' },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        '/connect/{instanceId}': {
+            post: {
+                tags: ['Instâncias'],
+                summary: 'Inicia o processo de conexão de uma instância.',
+                parameters: [{ $ref: '#/components/parameters/InstanceIdParam' }],
+                responses: {
+                    200: {
+                        description: 'Resultado da requisição de conexão.',
+                        content: {
+                            'application/json': {
+                                schema: { $ref: '#/components/schemas/ActionResponse' },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        '/disconnect/{instanceId}': {
+            post: {
+                tags: ['Instâncias'],
+                summary: 'Força a desconexão de uma instância conectada.',
+                parameters: [{ $ref: '#/components/parameters/InstanceIdParam' }],
+                responses: {
+                    200: {
+                        description: 'Resultado da tentativa de desconexão.',
+                        content: {
+                            'application/json': {
+                                schema: { $ref: '#/components/schemas/ActionResponse' },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        '/send/{instanceId}': {
+            post: {
+                tags: ['Mensagens'],
+                summary: 'Envia mensagens de texto ou mídias para um contato.',
+                parameters: [{ $ref: '#/components/parameters/InstanceIdParam' }],
+                requestBody: {
+                    required: true,
+                    content: {
+                        'application/json': {
+                            schema: { $ref: '#/components/schemas/SendRequest' },
+                        },
+                    },
+                },
+                responses: {
+                    200: {
+                        description: 'Mensagem aceita para envio.',
+                        content: {
+                            'application/json': {
+                                schema: { $ref: '#/components/schemas/SendSuccessResponse' },
+                            },
+                        },
+                    },
+                    400: {
+                        description: 'Requisição inválida ou instância não conectada.',
+                        content: {
+                            'application/json': {
+                                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                            },
+                        },
+                    },
+                    500: {
+                        description: 'Erro interno ao processar o envio.',
+                        content: {
+                            'application/json': {
+                                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        '/groups/{instanceId}': {
+            get: {
+                tags: ['Grupos'],
+                summary: 'Lista grupos associados à instância.',
+                parameters: [{ $ref: '#/components/parameters/InstanceIdParam' }],
+                responses: {
+                    200: {
+                        description: 'Grupos recuperados com sucesso.',
+                        content: {
+                            'application/json': {
+                                schema: { $ref: '#/components/schemas/GroupsResponse' },
+                            },
+                        },
+                    },
+                    400: {
+                        description: 'Instância não conectada ou inexistente.',
+                        content: {
+                            'application/json': {
+                                schema: { $ref: '#/components/schemas/GroupsResponse' },
+                            },
+                        },
+                    },
+                    500: {
+                        description: 'Erro interno ao consultar os grupos.',
+                        content: {
+                            'application/json': {
+                                schema: { $ref: '#/components/schemas/GroupsResponse' },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        '/health': {
+            get: {
+                tags: ['Utilitários'],
+                summary: 'Consulta o estado geral do serviço.',
+                responses: {
+                    200: {
+                        description: 'Informações de saúde do serviço.',
+                        content: {
+                            'application/json': {
+                                schema: { $ref: '#/components/schemas/HealthResponse' },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+};
+
+const swaggerSpec = swaggerJsdoc({ definition: swaggerDefinition, apis: [] });
+
+app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec, { explorer: true }));
+app.get('/docs.json', (req, res) => res.json(swaggerSpec));
 
 app.use((err, req, res, next) => {
     if (
@@ -826,7 +1190,6 @@ app.get('/health', (req, res) => {
     });
 });
 
-const PORT = process.env.PORT || 3002;
 app.listen(PORT, '0.0.0.0', () => {
     console.log(`🚀 Baileys service rodando na porta ${PORT}`);
     console.log(`📊 Health check: http://localhost:${PORT}/health`);


### PR DESCRIPTION
## Summary
- add swagger-jsdoc and swagger-ui-express dependencies to the Baileys service
- generate a complete OpenAPI specification covering status, QR, connection, messaging, groups and health endpoints
- serve Swagger UI at /docs and the raw JSON spec at /docs.json for external integrations and documentation needs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d349561694832f811058c6a0fb6ff5