### PR TITLE
Log payload Baileys antes do envio

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -9505,6 +9505,14 @@ class MessageScheduler:
                             f"📤 Enviando mensagem de mídia ao grupo {group_id} ({log_details})"
                         )
 
+                    try:
+                        payload_preview = json.dumps(payload, ensure_ascii=False)
+                    except (TypeError, ValueError):
+                        payload_preview = str(payload)
+                    print(
+                        f"console.log ▶️ Corpo da requisição para Baileys ({instance_id}): {payload_preview}"
+                    )
+
                     response = http.post(
                         f"{self.api_base_url}/send/{instance_id}",
                         json=payload,


### PR DESCRIPTION
## Summary
- adicionar log do corpo da requisição enviado ao serviço Baileys no momento do envio da mensagem
- garantir conversão segura do payload para JSON antes de registrar no console

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d35252c00c832fa27ded1ee0c13ac6